### PR TITLE
Feat/scout 22 seasons module

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -34,7 +34,7 @@
   "REGIONS": "Regions",
   "CLUB": "Club",
   "CLUBS": "Clubs",
-  "SEASON": "Seasom",
+  "SEASON": "Season",
   "SEASONS": "Seasons",
   "TEAM": "Team",
   "PRIMARY_POSITION": "Primary position",

--- a/public/locales/en/seasons.json
+++ b/public/locales/en/seasons.json
@@ -1,0 +1,14 @@
+{
+  "NO_NAME_ERROR": "Please provide season name",
+  "NO_START_DATE_ERROR": "Please provide start date",
+  "NO_END_DATE_ERROR": "Please provide end date",
+  "DELETE_CONFIRM_QUESTION": "Are you sure you want to delete season {{name}}?",
+  "INDEX_PAGE_TITLE": "Seasons database",
+  "CREATE_PAGE_TITLE": "Create new season",
+  "EDIT_PAGE_TITLE": "Edit season",
+  "START_DATE": "Start date",
+  "END_DATE": "End date",
+  "IS_ACTIVE": "Is active",
+  "SET_ACTIVE": "Set as active",
+  "UNSET_ACTIVE": "Set as not active"
+}

--- a/public/locales/pl/seasons.json
+++ b/public/locales/pl/seasons.json
@@ -3,7 +3,7 @@
   "NO_START_DATE_ERROR": "Podaj datę rozpoczęcia",
   "NO_END_DATE_ERROR": "Podaj datę zakończenia",
   "DELETE_CONFIRM_QUESTION": "Czy na pewno chcesz usunąć sezon {{name}}?",
-  "INDEX_PAGE_TITLE": "Baza sezonw",
+  "INDEX_PAGE_TITLE": "Baza sezonów",
   "CREATE_PAGE_TITLE": "Utwórz nowy sezon",
   "EDIT_PAGE_TITLE": "Edycja danych sezonu",
   "START_DATE": "Data rozpoczęcia",

--- a/public/locales/pl/seasons.json
+++ b/public/locales/pl/seasons.json
@@ -1,0 +1,14 @@
+{
+  "NO_NAME_ERROR": "Podaj nazwę sezonu",
+  "NO_START_DATE_ERROR": "Podaj datę rozpoczęcia",
+  "NO_END_DATE_ERROR": "Podaj datę zakończenia",
+  "DELETE_CONFIRM_QUESTION": "Czy na pewno chcesz usunąć sezon {{name}}?",
+  "INDEX_PAGE_TITLE": "Baza sezonw",
+  "CREATE_PAGE_TITLE": "Utwórz nowy sezon",
+  "EDIT_PAGE_TITLE": "Edycja danych sezonu",
+  "START_DATE": "Data rozpoczęcia",
+  "END_DATE": "Data zakończenia",
+  "IS_ACTIVE": "Czy jest aktywny",
+  "SET_ACTIVE": "Ustaw jako aktywny",
+  "UNSET_ACTIVE": "Ustaw jako nieaktywny"
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -13,6 +13,7 @@ export {
   SouthAmerica as RegionIcon,
   Assessment as ReportsIcon,
   Create as ReportTemplatesIcon,
+  AccessTime as SeasonIcon,
   Settings as SettingsIcon,
   GroupWork as TeamsIcon,
   Person as UserDataIcon,

--- a/src/components/nav/nav-list.tsx
+++ b/src/components/nav/nav-list.tsx
@@ -20,6 +20,7 @@ import {
   ProfileIcon,
   ReportsIcon,
   ReportTemplatesIcon,
+  SeasonIcon,
   SettingsIcon,
   TeamsIcon,
   UserDataIcon,
@@ -121,6 +122,11 @@ export const NavList = () => {
             icon={<CountryIcon color="error" />}
             to="/countries"
             text={t('COUNTRIES')}
+          />
+          <NavElement
+            icon={<SeasonIcon color="error" />}
+            to="/seasons"
+            text={t('SEASONS')}
           />
         </ExpandeableNavElement>
       )}

--- a/src/modules/seasons/details-card.tsx
+++ b/src/modules/seasons/details-card.tsx
@@ -1,0 +1,66 @@
+import {
+  Avatar,
+  Card,
+  CardContent,
+  CardHeader,
+  Grid
+} from '@mui/material'
+import { useTranslation } from 'next-i18next'
+
+import { CardItemBasic } from '@/components/details-card-item'
+import { SeasonIcon } from '@/components/icons'
+import { formatDate } from '@/utils/format-date'
+
+import { SeasonDto } from './types'
+
+export const SeasonDetailsCard = ({ season }: IDetailsCard) => {
+  const { t } = useTranslation()
+
+  const {
+    name,
+    endDate,
+    startDate,
+    isActive
+  } = season
+
+  return (
+    <Card sx={{ maxWidth: 700, margin: '0 auto' }}>
+      <CardHeader
+        avatar={
+          <Avatar
+            aria-label="season icon"
+            sx={{ backgroundColor: 'secondary.main', width: 50, height: 50 }}
+          >
+            <SeasonIcon />
+          </Avatar>
+        }
+        title={name}
+        titleTypographyProps={{ variant: 'h3' }}
+      />
+      <CardContent>
+        <Grid container spacing={1}>
+          <CardItemBasic
+            categ={t('NAME')}
+            value={name}
+          />
+          <CardItemBasic
+            categ={t('seasons:START_DATE')}
+            value={formatDate(startDate)}
+          />
+          <CardItemBasic
+            categ={t('seasons:END_DATE')}
+            value={formatDate(endDate)}
+          />
+          <CardItemBasic
+            categ={t('seasons:IS_ACTIVE')}
+            value={isActive ? t('YES') : t('NO')}
+          />
+        </Grid>
+      </CardContent>
+    </Card>
+  )
+}
+
+interface IDetailsCard {
+  season: SeasonDto
+}

--- a/src/modules/seasons/forms/create.tsx
+++ b/src/modules/seasons/forms/create.tsx
@@ -1,0 +1,83 @@
+import { TextField } from '@mui/material'
+import { Field, Form, Formik } from 'formik'
+import filter from 'just-filter-object'
+import { useTranslation } from 'next-i18next'
+
+import { Container } from '@/components/forms/container'
+import { MainFormActions } from '@/components/forms/main-form-actions'
+import { useAlertsState } from '@/context/alerts/useAlertsState'
+
+import { CreateSeasonDto } from '../types'
+import { generateCreateValidationSchema, initialValues } from './utils'
+
+interface ICreateFormProps {
+  onSubmit: (data: CreateSeasonDto) => void
+  onCancelClick?: () => void
+  fullwidth?: boolean
+}
+
+export const CreateSeasonForm = ({
+  onSubmit,
+  onCancelClick,
+  fullwidth
+}: ICreateFormProps) => {
+  const { setAlert } = useAlertsState()
+  const { t } = useTranslation()
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={generateCreateValidationSchema(t)}
+      enableReinitialize
+      onSubmit={(data, { resetForm }) => {
+        const dataToSubmit = filter(data, (_, value) => value)
+        onSubmit(dataToSubmit as CreateSeasonDto)
+        resetForm()
+      }}
+    >
+      {({ handleReset, touched, errors }) => (
+        <Form>
+          <Container fullwidth={fullwidth}>
+            <Field
+              name="name"
+              as={TextField}
+              variant="outlined"
+              fullWidth
+              label={t('NAME')}
+              error={touched.name && !!errors.name}
+              helperText={touched.name && errors.name}
+            />
+            <Field
+              name="startDate"
+              as={TextField}
+              variant="outlined"
+              fullWidth
+              label={t('seasons:START_DATE')}
+              error={touched.startDate && !!errors.startDate}
+              helperText={touched.startDate && errors.startDate}
+            />
+            <Field
+              name="endDate"
+              as={TextField}
+              variant="outlined"
+              fullWidth
+              label={t('seasons:END_DATE')}
+              error={touched.endDate && !!errors.endDate}
+              helperText={touched.endDate && errors.endDate}
+            />
+            <MainFormActions
+              label={t('SEASON')}
+              onCancelClick={() => {
+                if (onCancelClick) {
+                  onCancelClick()
+                }
+                handleReset()
+                setAlert({ msg: t('CHANGES_CANCELLED'), type: 'warning' })
+              }}
+            />
+          </Container>
+        </Form>
+      )}
+    </Formik>
+  )
+}

--- a/src/modules/seasons/forms/create.tsx
+++ b/src/modules/seasons/forms/create.tsx
@@ -50,6 +50,7 @@ export const CreateSeasonForm = ({
             <Field
               name="startDate"
               as={TextField}
+              type='date'
               variant="outlined"
               fullWidth
               label={t('seasons:START_DATE')}
@@ -59,6 +60,7 @@ export const CreateSeasonForm = ({
             <Field
               name="endDate"
               as={TextField}
+              type='date'
               variant="outlined"
               fullWidth
               label={t('seasons:END_DATE')}

--- a/src/modules/seasons/forms/edit.tsx
+++ b/src/modules/seasons/forms/edit.tsx
@@ -1,0 +1,94 @@
+import { TextField } from '@mui/material'
+import { updatedDiff } from 'deep-object-diff'
+import { Field, Form, Formik } from 'formik'
+import filter from 'just-filter-object'
+import { useTranslation } from 'next-i18next'
+
+import { Container } from '@/components/forms/container'
+import { MainFormActions } from '@/components/forms/main-form-actions'
+import { useAlertsState } from '@/context/alerts/useAlertsState'
+
+import { SeasonDto, UpdateSeasonDto } from '../types'
+import {
+  generateUpdateValidationSchema,
+  getInitialStateFromCurrent,
+} from './utils'
+
+interface IEditFormProps {
+  current: SeasonDto
+  onSubmit: (data: UpdateSeasonDto) => void
+  onCancelClick?: () => void
+  fullwidth?: boolean
+}
+
+export const EditSeasonForm = ({
+  current,
+  onSubmit,
+  onCancelClick,
+  fullwidth
+}: IEditFormProps) => {
+  const { setAlert } = useAlertsState()
+  const { t } = useTranslation()
+
+  const initialValues = getInitialStateFromCurrent(current)
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={() => generateUpdateValidationSchema()}
+      enableReinitialize
+      onSubmit={data => {
+        const dataToSubmit = updatedDiff(
+          initialValues,
+          filter(data, (_, value) => value),
+        )
+        onSubmit(dataToSubmit)
+      }}
+    >
+      {({ handleReset, touched, errors }) => (
+        <Form>
+          <Container fullwidth={fullwidth}>
+            <Field
+              name="name"
+              as={TextField}
+              variant="outlined"
+              fullWidth
+              label={t('NAME')}
+              error={touched.name && !!errors.name}
+              helperText={touched.name && errors.name}
+            />
+            <Field
+              name="startDate"
+              as={TextField}
+              variant="outlined"
+              fullWidth
+              label={t('seasons:START_DATE')}
+              error={touched.startDate && !!errors.startDate}
+              helperText={touched.startDate && errors.startDate}
+            />
+            <Field
+              name="endDate"
+              as={TextField}
+              variant="outlined"
+              fullWidth
+              label={t('seasons:END_DATE')}
+              error={touched.endDate && !!errors.endDate}
+              helperText={touched.endDate && errors.endDate}
+            />
+            <MainFormActions
+              label={t('SEASON')}
+              isEditState
+              onCancelClick={() => {
+                if (onCancelClick) {
+                  onCancelClick()
+                }
+                handleReset()
+                setAlert({ msg: t('CHANGES_CANCELLED'), type: 'warning' })
+              }}
+            />
+          </Container>
+        </Form>
+      )}
+    </Formik>
+  )
+}

--- a/src/modules/seasons/forms/edit.tsx
+++ b/src/modules/seasons/forms/edit.tsx
@@ -60,6 +60,7 @@ export const EditSeasonForm = ({
             <Field
               name="startDate"
               as={TextField}
+              type='date'
               variant="outlined"
               fullWidth
               label={t('seasons:START_DATE')}
@@ -69,6 +70,7 @@ export const EditSeasonForm = ({
             <Field
               name="endDate"
               as={TextField}
+              type='date'
               variant="outlined"
               fullWidth
               label={t('seasons:END_DATE')}

--- a/src/modules/seasons/forms/utils.ts
+++ b/src/modules/seasons/forms/utils.ts
@@ -2,12 +2,14 @@ import map from 'just-map-values'
 import { TFunction } from 'next-i18next'
 import * as yup from 'yup'
 
+import { formatDate } from '@/utils/format-date'
+
 import { CreateSeasonDto, SeasonDto, UpdateSeasonDto } from '../types'
 
 export const initialValues: CreateSeasonDto = {
   name: '',
-  endDate: '',
-  startDate: '',
+  endDate: formatDate(),
+  startDate: formatDate(),
 }
 
 export function generateCreateValidationSchema(t: TFunction) {
@@ -33,9 +35,13 @@ export function getInitialStateFromCurrent(season: SeasonDto): UpdateSeasonDto {
 
   const values = {
     name,
-    endDate,
-    startDate,
   }
 
-  return map(values, value => value || '')
+  const mapped = map(values, value => value || '')
+
+  return {
+    endDate: formatDate(endDate),
+    startDate: formatDate(startDate),
+    ...mapped,
+  }
 }

--- a/src/modules/seasons/forms/utils.ts
+++ b/src/modules/seasons/forms/utils.ts
@@ -1,0 +1,41 @@
+import map from 'just-map-values'
+import { TFunction } from 'next-i18next'
+import * as yup from 'yup'
+
+import { CreateSeasonDto, SeasonDto, UpdateSeasonDto } from '../types'
+
+export const initialValues: CreateSeasonDto = {
+  name: '',
+  endDate: '',
+  startDate: '',
+}
+
+export function generateCreateValidationSchema(t: TFunction) {
+  return yup
+    .object({
+      name: yup.string().required(t('seasons:NO_NAME_ERROR')),
+      startDate: yup.date().required(t('seasons:NO_START_DATE_ERROR')),
+      endDate: yup.date().required(t('seasons:NO_END_DATE_ERROR')),
+    })
+    .defined()
+}
+
+export function generateUpdateValidationSchema() {
+  return yup.object({
+    name: yup.string().notRequired(),
+    startDate: yup.date().notRequired(),
+    endDate: yup.date().notRequired(),
+  })
+}
+
+export function getInitialStateFromCurrent(season: SeasonDto): UpdateSeasonDto {
+  const { name, endDate, startDate } = season
+
+  const values = {
+    name,
+    endDate,
+    startDate,
+  }
+
+  return map(values, value => value || '')
+}

--- a/src/modules/seasons/hooks.ts
+++ b/src/modules/seasons/hooks.ts
@@ -1,9 +1,39 @@
-import { SeasonDto } from '@/modules/seasons/types'
-import { getSeasonsList } from '@/services/api/methods/seasons'
+import {
+  CreateSeasonDto,
+  SeasonDto,
+  UpdateSeasonDto,
+} from '@/modules/seasons/types'
+import {
+  createSeason,
+  deleteSeason,
+  getSeasonsList,
+  setActiveSeason,
+  unSetActiveSeason,
+  updateSeason,
+} from '@/services/api/methods/seasons'
 import { TModuleName } from '@/services/api/modules'
+import { useCreateDocument } from '@/utils/hooks/api/use-create-document'
+import { useDeleteDocument } from '@/utils/hooks/api/use-delete-document'
 import { useList } from '@/utils/hooks/api/use-list'
+import { useToggleActiveDocument } from '@/utils/hooks/api/use-toggle-active-document'
+import { useUpdateDocument } from '@/utils/hooks/api/use-update-document'
 
 const moduleName: TModuleName = 'seasons'
 
 export const useSeasonsList = () =>
   useList<SeasonDto>(moduleName, getSeasonsList)
+
+export const useDeleteSeason = () =>
+  useDeleteDocument<SeasonDto>(moduleName, deleteSeason)
+
+export const useUpdateSeason = (id: number) =>
+  useUpdateDocument<UpdateSeasonDto, SeasonDto>(moduleName, id, updateSeason)
+
+export const useCreateSeason = () =>
+  useCreateDocument<CreateSeasonDto, SeasonDto>(moduleName, createSeason)
+
+export const useSetActiveSeason = () =>
+  useToggleActiveDocument<SeasonDto>(moduleName, setActiveSeason)
+
+export const useUnSetActiveSeason = () =>
+  useToggleActiveDocument<SeasonDto>(moduleName, unSetActiveSeason)

--- a/src/modules/seasons/table/row.tsx
+++ b/src/modules/seasons/table/row.tsx
@@ -1,0 +1,105 @@
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  Edit as EditIcon,
+  Remove as RemoveIcon
+} from '@mui/icons-material'
+import { useRouter } from 'next/router'
+import { useTranslation } from 'next-i18next'
+
+import { StyledTableCell } from '@/components/tables/cell'
+import { TableMenu } from '@/components/tables/menu'
+import { TableMenuItem } from '@/components/tables/menu-item'
+import { StyledTableRow } from '@/components/tables/row'
+import { formatDate } from '@/utils/format-date'
+import { useTableMenu } from '@/utils/hooks/use-table-menu'
+
+import { SeasonDto } from '../types'
+
+interface ITableRowProps {
+  data: SeasonDto
+  onEditClick: () => void
+  onDeleteClick: () => void
+  isEditOptionEnabled: boolean
+  isDeleteOptionEnabled: boolean
+  onSetActiveClick: (id: number) => void
+  onUnSetActiveClick: (id: number) => void
+}
+
+export const SeasonsTableRow = ({
+  data,
+  onEditClick,
+  onDeleteClick,
+  isEditOptionEnabled,
+  isDeleteOptionEnabled,
+  onSetActiveClick,
+  onUnSetActiveClick
+}: ITableRowProps) => {
+  const router = useRouter()
+  const { t } = useTranslation()
+
+  const {
+    menuAnchorEl,
+    isMenuOpen,
+    handleMenuClick,
+    handleMenuClose,
+    handleMenuAction,
+  } = useTableMenu()
+
+  const { id, name, endDate, startDate, isActive } = data
+
+  return (
+    <StyledTableRow
+      hover
+      key={id}
+      onClick={isMenuOpen ? undefined : () => router.push(`/seasons/${id}`)}
+    >
+      <StyledTableCell padding="checkbox">
+        <TableMenu
+          menuAnchorEl={menuAnchorEl}
+          isMenuOpen={isMenuOpen}
+          onMenuClick={handleMenuClick}
+          onMenuClose={handleMenuClose}
+        >
+          <TableMenuItem
+            icon={<EditIcon fontSize="small" />}
+            text={t('EDIT')}
+            onClick={() => {
+              handleMenuAction(onEditClick)
+            }}
+            disabled={!isEditOptionEnabled}
+          />
+          <TableMenuItem
+            icon={<DeleteIcon fontSize="small" />}
+            text={t('DELETE')}
+            onClick={() => {
+              handleMenuAction(onDeleteClick)
+            }}
+            disabled={!isDeleteOptionEnabled}
+          />
+          {!isActive ? (
+            <TableMenuItem
+              icon={<AddIcon fontSize="small" />}
+              text={t('seasons:SET_ACTIVE')}
+              onClick={() => {
+                handleMenuAction(() => onSetActiveClick(id))
+              }}
+            />
+          ) : (
+            <TableMenuItem
+              icon={<RemoveIcon fontSize="small" />}
+              text={t('seasons:UNSET_ACTIVE')}
+              onClick={() => {
+                handleMenuAction(() => onUnSetActiveClick(id))
+              }}
+            />
+          )}
+        </TableMenu>
+      </StyledTableCell>
+      <StyledTableCell>{name}</StyledTableCell>
+      <StyledTableCell>{formatDate(startDate)}</StyledTableCell>
+      <StyledTableCell>{formatDate(endDate)}</StyledTableCell>
+      <StyledTableCell>{isActive ? t('YES') : t('NO')}</StyledTableCell>
+    </StyledTableRow>
+  )
+}

--- a/src/modules/seasons/table/table.tsx
+++ b/src/modules/seasons/table/table.tsx
@@ -1,0 +1,50 @@
+import { TFunction, useTranslation } from 'next-i18next'
+import { ReactNode } from 'react'
+
+import { Table } from '@/components/tables/table'
+import { ICommonTableProps, IHeadCell } from '@/types/tables'
+
+interface ITableProps extends ICommonTableProps {
+  children: ReactNode
+}
+
+function generateHeadCells(t: TFunction): IHeadCell[] {
+  return [
+    { id: 'name', label: t('NAME'), isSortingDisabled: true },
+    { id: 'startDate', label: t('seasons:START_DATE'), isSortingDisabled: true },
+    { id: 'endDate', label: t('seasons:END_DATE'), isSortingDisabled: true },
+    { id: 'isActive', label: t('seasons:IS_ACTIVE'), isSortingDisabled: true }
+  ]
+}
+
+export const SeasonsTable = ({
+  page,
+  rowsPerPage,
+  sortBy,
+  order,
+  handleChangePage,
+  handleChangeRowsPerPage,
+  handleSort,
+  total,
+  actions,
+  children,
+}: ITableProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Table
+      page={page}
+      rowsPerPage={rowsPerPage}
+      sortBy={sortBy}
+      order={order}
+      handleChangePage={handleChangePage}
+      handleChangeRowsPerPage={handleChangeRowsPerPage}
+      handleSort={handleSort}
+      total={total}
+      headCells={generateHeadCells(t)}
+      actions={actions}
+    >
+      {children}
+    </Table>
+  )
+}

--- a/src/modules/seasons/types.ts
+++ b/src/modules/seasons/types.ts
@@ -1,1 +1,11 @@
 export type SeasonDto = Components.Schemas.SeasonDto
+
+export type CreateSeasonDto = Components.Schemas.CreateSeasonDto
+
+export type UpdateSeasonDto = Components.Schemas.UpdateSeasonDto
+
+// nothing at the moment
+export type FindAllSeasonsParams = {}
+
+// nothing at the moment
+export type SeasonsFiltersDto = {}

--- a/src/pages/seasons/[id].tsx
+++ b/src/pages/seasons/[id].tsx
@@ -24,7 +24,7 @@ export const getServerSideProps = withSessionSsrRole<SeasonDto>(['common', 'seas
     }
   });
 
-const MatchPage = ({ data, errorMessage, errorStatus }: TSsrRole<SeasonDto>) => {
+const SeasonPage = ({ data, errorMessage, errorStatus }: TSsrRole<SeasonDto>) => {
   const { t } = useTranslation()
 
   if (!data) return <ErrorContent message={errorMessage} status={errorStatus} />
@@ -36,4 +36,4 @@ const MatchPage = ({ data, errorMessage, errorStatus }: TSsrRole<SeasonDto>) => 
   )
 }
 
-export default MatchPage
+export default SeasonPage

--- a/src/pages/seasons/[id].tsx
+++ b/src/pages/seasons/[id].tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from 'next-i18next'
+
+import { ErrorContent } from '@/components/error/error-content'
+import { PageHeading } from '@/components/page-heading/page-heading'
+import { SeasonDetailsCard } from '@/modules/seasons/details-card'
+import { SeasonDto } from '@/modules/seasons/types'
+import { getSeasonById } from '@/services/api/methods/seasons'
+import { ApiError } from '@/services/api/types'
+import { TSsrRole, withSessionSsrRole } from '@/utils/withSessionSsrRole'
+
+export const getServerSideProps = withSessionSsrRole<SeasonDto>(['common', 'seasons'], ['ADMIN'],
+  async (token, params) => {
+    try {
+      const data = await getSeasonById(
+        +(params?.id as string),
+        token,
+      )
+      return { data }
+    } catch (error) {
+      return {
+        data: null,
+        error: error as ApiError
+      }
+    }
+  });
+
+const MatchPage = ({ data, errorMessage, errorStatus }: TSsrRole<SeasonDto>) => {
+  const { t } = useTranslation()
+
+  if (!data) return <ErrorContent message={errorMessage} status={errorStatus} />
+  return (
+    <>
+      <PageHeading title={t('SEASON')} />
+      <SeasonDetailsCard season={data} />
+    </>
+  )
+}
+
+export default MatchPage

--- a/src/pages/seasons/create.tsx
+++ b/src/pages/seasons/create.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'next-i18next'
+
+import { ErrorContent } from '@/components/error/error-content'
+import { Loader } from '@/components/loader/loader'
+import { PageHeading } from '@/components/page-heading/page-heading'
+import { CreateSeasonForm } from '@/modules/seasons/forms/create'
+import { useCreateSeason } from '@/modules/seasons/hooks'
+import { TSsrRole, withSessionSsrRole } from '@/utils/withSessionSsrRole'
+
+export const getServerSideProps = withSessionSsrRole(['common', 'seasons'], ['ADMIN'])
+
+const CreateSeasonPage = ({ errorMessage, errorStatus }: TSsrRole) => {
+  const { t } = useTranslation()
+
+  const { mutate: createSeason, isLoading: createLoading } = useCreateSeason()
+
+  if (errorStatus) return <ErrorContent message={errorMessage} status={errorStatus} />
+  return (
+    <>
+      {createLoading && <Loader />}
+      <PageHeading title={t('seasons:CREATE_PAGE_TITLE')} />
+      <CreateSeasonForm
+        onSubmit={createSeason}
+      />
+    </>
+  )
+}
+
+export default CreateSeasonPage

--- a/src/pages/seasons/edit/[id].tsx
+++ b/src/pages/seasons/edit/[id].tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'next-i18next'
+
+import { ErrorContent } from '@/components/error/error-content'
+import { Loader } from '@/components/loader/loader'
+import { PageHeading } from '@/components/page-heading/page-heading'
+import { EditSeasonForm } from '@/modules/seasons/forms/edit'
+import { useUpdateSeason } from '@/modules/seasons/hooks'
+import { SeasonDto } from '@/modules/seasons/types'
+import { getSeasonById } from '@/services/api/methods/seasons'
+import { ApiError } from '@/services/api/types'
+import { TSsrRole, withSessionSsrRole } from '@/utils/withSessionSsrRole'
+
+export const getServerSideProps = withSessionSsrRole<SeasonDto>(['common', 'seasons'], ['ADMIN'],
+  async (token, params) => {
+    try {
+      const data = await getSeasonById(
+        +(params?.id as string),
+        token,
+      )
+      return { data }
+    } catch (error) {
+      return {
+        data: null,
+        error: error as ApiError
+      }
+    }
+  });
+
+const EditSeasonPage = ({
+  data,
+  errorMessage,
+  errorStatus,
+}: TSsrRole<SeasonDto>) => {
+  const { t } = useTranslation()
+
+  const { mutate: updateSeason, isLoading: updateLoading } = useUpdateSeason(
+    data?.id || 0,
+  )
+
+  if (!data || errorStatus) return <ErrorContent message={errorMessage} status={errorStatus} />
+  return (
+    <>
+      {updateLoading && <Loader />}
+      <PageHeading
+        title={t('seasons:EDIT_PAGE_TITLE')}
+      />
+      <EditSeasonForm
+        current={data}
+        onSubmit={updateSeason}
+      />
+    </>
+  )
+}
+
+export default EditSeasonPage

--- a/src/pages/seasons/index.tsx
+++ b/src/pages/seasons/index.tsx
@@ -1,0 +1,105 @@
+import { useRouter } from 'next/router'
+import { useTranslation } from 'next-i18next'
+import { useState } from 'react'
+
+import { ErrorContent } from '@/components/error/error-content'
+import { Fab } from '@/components/fab/fab'
+import { Loader } from '@/components/loader/loader'
+import { ConfirmationModal } from '@/components/modals/confirmation-modal'
+import { PageHeading } from '@/components/page-heading/page-heading'
+import { useDeleteSeason, useSeasonsList, useSetActiveSeason, useUnSetActiveSeason } from '@/modules/seasons/hooks'
+import { SeasonsTableRow } from '@/modules/seasons/table/row'
+import { SeasonsTable } from '@/modules/seasons/table/table'
+import { useTable } from '@/utils/hooks/use-table'
+import { TSsrRole, withSessionSsrRole } from '@/utils/withSessionSsrRole'
+
+export const getServerSideProps = withSessionSsrRole(['common', 'seasons'], ['ADMIN'])
+
+interface IToDeleteData {
+  id: number
+  name: string
+}
+
+const SeasonsPage = ({ errorMessage, errorStatus }: TSsrRole) => {
+  const { t } = useTranslation()
+  const router = useRouter()
+
+  const [isDeleteConfirmationModalOpen, setIsDeleteConfirmationModalOpen] =
+    useState(false)
+  const [toDeleteData, setToDeleteData] =
+    useState<IToDeleteData>()
+
+  const {
+    tableSettings: { page, rowsPerPage, sortBy, order },
+    handleChangePage,
+    handleChangeRowsPerPage,
+    handleSort,
+  } = useTable('seasonsTable')
+
+  const { data: seasons, isLoading: dataLoading } = useSeasonsList()
+
+  const { mutate: deleteSeason, isLoading: deleteLoading } = useDeleteSeason()
+
+  const { mutate: setActiveSeason, isLoading: setActiveLoading } = useSetActiveSeason()
+  const { mutate: unSetActiveSeason, isLoading: unSetActiveLoading } = useUnSetActiveSeason()
+
+  const isLoading = dataLoading || deleteLoading || setActiveLoading || unSetActiveLoading
+
+  if (errorStatus) return <ErrorContent message={errorMessage} status={errorStatus} />
+  return (
+    <>
+      {isLoading && <Loader />}
+      <PageHeading title={t('seasons:INDEX_PAGE_TITLE')} />
+      <SeasonsTable
+        page={page}
+        rowsPerPage={rowsPerPage}
+        sortBy={sortBy}
+        order={order}
+        handleChangePage={handleChangePage}
+        handleChangeRowsPerPage={handleChangeRowsPerPage}
+        handleSort={handleSort}
+        total={seasons?.length || 0}
+        actions
+      >
+        {!!seasons &&
+          seasons.map(season => (
+            <SeasonsTableRow
+              key={season.id}
+              data={season}
+              onEditClick={() => {
+                router.push(`/seasons/edit/${season.id}`)
+              }}
+              onDeleteClick={() => {
+                setToDeleteData({ id: season.id, name: season.name })
+                setIsDeleteConfirmationModalOpen(true)
+              }}
+              onSetActiveClick={(id: number) => setActiveSeason(id)}
+              onUnSetActiveClick={(id: number) => unSetActiveSeason(id)}
+              isEditOptionEnabled
+              isDeleteOptionEnabled
+            />
+          ))
+        }
+      </SeasonsTable>
+      <Fab href="/seasons/create" />
+      <ConfirmationModal
+        open={isDeleteConfirmationModalOpen}
+        message={t('seasons:DELETE_CONFIRM_QUESTION', {
+          name: toDeleteData?.name,
+        })}
+        handleAccept={() => {
+          if (toDeleteData)
+            deleteSeason(toDeleteData.id)
+
+          setToDeleteData(undefined)
+        }}
+        handleClose={() => {
+          setIsDeleteConfirmationModalOpen(false)
+          setToDeleteData(undefined)
+        }}
+      />
+    </>
+  )
+}
+
+export default SeasonsPage

--- a/src/services/api/methods/helpers.ts
+++ b/src/services/api/methods/helpers.ts
@@ -136,3 +136,27 @@ export async function unlikeDocument<ReturnType>(
   )
   return data
 }
+
+// set active document
+export async function setActiveDocument<ReturnType>(
+  id: number,
+  moduleName: TModuleName,
+): Promise<ApiResponse<ReturnType>> {
+  const { data } = await client.patch<ApiResponse<ReturnType>>(
+    `/${moduleName}/${id}/toggle-active`,
+    { isActive: true },
+  )
+  return data
+}
+
+// unset active document
+export async function unSetActiveDocument<ReturnType>(
+  id: number,
+  moduleName: TModuleName,
+): Promise<ApiResponse<ReturnType>> {
+  const { data } = await client.patch<ApiResponse<ReturnType>>(
+    `/${moduleName}/${id}/toggle-active`,
+    { isActive: false },
+  )
+  return data
+}

--- a/src/services/api/methods/helpers.ts
+++ b/src/services/api/methods/helpers.ts
@@ -136,27 +136,3 @@ export async function unlikeDocument<ReturnType>(
   )
   return data
 }
-
-// set active document
-export async function setActiveDocument<ReturnType>(
-  id: number,
-  moduleName: TModuleName,
-): Promise<ApiResponse<ReturnType>> {
-  const { data } = await client.patch<ApiResponse<ReturnType>>(
-    `/${moduleName}/${id}/toggle-active`,
-    { isActive: true },
-  )
-  return data
-}
-
-// unset active document
-export async function unSetActiveDocument<ReturnType>(
-  id: number,
-  moduleName: TModuleName,
-): Promise<ApiResponse<ReturnType>> {
-  const { data } = await client.patch<ApiResponse<ReturnType>>(
-    `/${moduleName}/${id}/toggle-active`,
-    { isActive: false },
-  )
-  return data
-}

--- a/src/services/api/methods/seasons.ts
+++ b/src/services/api/methods/seasons.ts
@@ -8,11 +8,12 @@ import {
   deleteDocument,
   getAssetById,
   getDataList,
-  setActiveDocument,
-  unSetActiveDocument,
   updateDocument,
 } from '@/services/api/methods/helpers'
 import { TModuleName } from '@/services/api/modules'
+
+import { client } from '../api'
+import { ApiResponse } from '../types'
 
 const moduleName: TModuleName = 'seasons'
 
@@ -35,7 +36,18 @@ export const getSeasonById = (id: number, token?: string) =>
   getAssetById<SeasonDto>({ moduleName, id, token })
 
 export const setActiveSeason = (id: number) =>
-  setActiveDocument<SeasonDto>(id, moduleName)
+  toggleActiveDocument<SeasonDto>(id, true)
 
 export const unSetActiveSeason = (id: number) =>
-  unSetActiveDocument<SeasonDto>(id, moduleName)
+  toggleActiveDocument<SeasonDto>(id, false)
+
+async function toggleActiveDocument<ReturnType>(
+  id: number,
+  activeState: boolean,
+): Promise<ApiResponse<ReturnType>> {
+  const { data } = await client.patch<ApiResponse<ReturnType>>(
+    `/${moduleName}/${id}/toggle-active`,
+    { isActive: activeState },
+  )
+  return data
+}

--- a/src/services/api/methods/seasons.ts
+++ b/src/services/api/methods/seasons.ts
@@ -1,7 +1,41 @@
-import { SeasonDto } from '@/modules/seasons/types'
-import { getDataList } from '@/services/api/methods/helpers'
+import {
+  CreateSeasonDto,
+  SeasonDto,
+  UpdateSeasonDto,
+} from '@/modules/seasons/types'
+import {
+  createDocument,
+  deleteDocument,
+  getAssetById,
+  getDataList,
+  setActiveDocument,
+  unSetActiveDocument,
+  updateDocument,
+} from '@/services/api/methods/helpers'
 import { TModuleName } from '@/services/api/modules'
 
 const moduleName: TModuleName = 'seasons'
 
 export const getSeasonsList = () => getDataList<SeasonDto>(moduleName)
+
+export const deleteSeason = (id: number) =>
+  deleteDocument<SeasonDto>(id, moduleName)
+
+interface IUpdateArgs {
+  id: number
+  data: UpdateSeasonDto
+}
+export const updateSeason = ({ id, data }: IUpdateArgs) =>
+  updateDocument<UpdateSeasonDto, SeasonDto>(id, data, moduleName)
+
+export const createSeason = (data: CreateSeasonDto) =>
+  createDocument<CreateSeasonDto, SeasonDto>(data, moduleName)
+
+export const getSeasonById = (id: number, token?: string) =>
+  getAssetById<SeasonDto>({ moduleName, id, token })
+
+export const setActiveSeason = (id: number) =>
+  setActiveDocument<SeasonDto>(id, moduleName)
+
+export const unSetActiveSeason = (id: number) =>
+  unSetActiveDocument<SeasonDto>(id, moduleName)

--- a/src/utils/hooks/api/use-toggle-active-document.ts
+++ b/src/utils/hooks/api/use-toggle-active-document.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from 'react-query'
+
+import { useAlertsState } from '@/context/alerts/useAlertsState'
+import { ApiError, ApiResponse } from '@/services/api/types'
+
+export function useToggleActiveDocument<DataType>(
+  key: string,
+  mutationFn: (id: number) => Promise<ApiResponse<DataType>>,
+) {
+  const queryClient = useQueryClient()
+  const { setAlert } = useAlertsState()
+
+  return useMutation((id: number) => mutationFn(id), {
+    onSuccess: data => {
+      setAlert({
+        msg: data.message,
+        type: 'success',
+      })
+      queryClient.invalidateQueries(key)
+    },
+    onError: (err: ApiError) =>
+      setAlert({
+        msg: err.response.data.message,
+        type: 'error',
+      }),
+  })
+}


### PR DESCRIPTION
[SCOUT-22](https://playmakerpro.atlassian.net/browse/SCOUT-22?atlOrigin=eyJpIjoiMzcxZTkwZDI4NjZjNDdhMTk5MTVjNzRhYTQzMDFhMTUiLCJwIjoiaiJ9)

### Task Description
Seasons module
- table
- create/edit form
- translations
- index/create/edit/id pages
- admin role check
- add to admin panel
- set/unset active season in table menu (+ new hooks)

### Additional Notes (optional)
- no filter form as there's literally no filtering for seasons
- depends on order of setting/unsetting active season sometimes a reload is needed to refresh data display