### PR TITLE
[SCOUT-163] combo components

### DIFF
--- a/src/components/combo/combo.tsx
+++ b/src/components/combo/combo.tsx
@@ -1,0 +1,45 @@
+import { AutocompleteRenderInputParams, TextField } from '@mui/material'
+import { Field } from 'formik'
+import { Autocomplete } from 'formik-mui'
+
+import { IComboOptions } from './types'
+
+interface IComboProps {
+  data: IComboOptions[]
+  name: string
+  label: string
+  multiple?: boolean
+  size?: 'medium' | 'small'
+  error?: boolean
+  helperText?: string
+}
+
+export const Combo = ({
+  data,
+  name,
+  label,
+  multiple,
+  size,
+  error,
+  helperText,
+}: IComboProps) => (
+  <Field
+    name={name}
+    component={Autocomplete}
+    limitTags={3}
+    multiple={multiple}
+    id={name}
+    size={size}
+    options={data}
+    filterSelectedOptions
+    renderInput={(params: AutocompleteRenderInputParams) => (
+      <TextField
+        {...params}
+        error={error}
+        helperText={helperText}
+        label={label}
+        placeholder={label}
+      />
+    )}
+  />
+)

--- a/src/components/combo/types.ts
+++ b/src/components/combo/types.ts
@@ -1,0 +1,4 @@
+export interface IComboOptions {
+  id: string
+  label: string
+}

--- a/src/modules/competition-groups/utils.ts
+++ b/src/modules/competition-groups/utils.ts
@@ -1,0 +1,12 @@
+import { IComboOptions } from '@/components/combo/types'
+
+import { CompetitionGroupBasicDataDto } from './types'
+
+export function mapCompetitionGroupsListToComboOptions(
+  data: CompetitionGroupBasicDataDto[],
+): IComboOptions[] {
+  return data.map(({ id, name, competition }) => ({
+    id,
+    label: `${competition.name}, ${name} (${competition.country.code})`,
+  }))
+}

--- a/src/modules/competitions/utils.ts
+++ b/src/modules/competitions/utils.ts
@@ -1,0 +1,12 @@
+import { IComboOptions } from '@/components/combo/types'
+
+import { CompetitionBasicDataDto } from './types'
+
+export function mapCompetitionsListToComboOptions(
+  data: CompetitionBasicDataDto[],
+): IComboOptions[] {
+  return data.map(({ id, name, country }) => ({
+    id,
+    label: `${name} (${country.code})`,
+  }))
+}

--- a/src/modules/countries/utils.ts
+++ b/src/modules/countries/utils.ts
@@ -1,0 +1,12 @@
+import { IComboOptions } from '@/components/combo/types'
+
+import { CountryDto } from './types'
+
+export function mapCountriesListToComboOptions(
+  data: CountryDto[],
+): IComboOptions[] {
+  return data.map(({ id, name }) => ({
+    id,
+    label: name,
+  }))
+}

--- a/src/modules/player-positions/utils.ts
+++ b/src/modules/player-positions/utils.ts
@@ -1,0 +1,12 @@
+import { IComboOptions } from '@/components/combo/types'
+
+import { PlayerPositionDto } from './types'
+
+export function mapPositionsListToComboOptions(
+  data: PlayerPositionDto[],
+): IComboOptions[] {
+  return data.map(({ id, name }) => ({
+    id,
+    label: name,
+  }))
+}

--- a/src/modules/players/forms/filter.tsx
+++ b/src/modules/players/forms/filter.tsx
@@ -4,20 +4,21 @@ import { Field, Form, Formik } from 'formik'
 import { CheckboxWithLabel } from 'formik-mui'
 import { useTranslation } from 'next-i18next'
 
+import { Combo } from '@/components/combo/combo'
 import { Container } from '@/components/forms/container'
 import { FilterFormActions } from '@/components/forms/filter-form-actions'
-import { CompetitionGroupsCombo } from '@/modules/competition-groups/combo'
 import { CompetitionGroupBasicDataDto } from '@/modules/competition-groups/types'
-import { CompetitionsCombo } from '@/modules/competitions/combo'
+import { mapCompetitionGroupsListToComboOptions } from '@/modules/competition-groups/utils'
 import { CompetitionBasicDataDto } from '@/modules/competitions/types'
-import { CountriesCombo } from '@/modules/countries/combo'
+import { mapCompetitionsListToComboOptions } from '@/modules/competitions/utils'
 import { CountryDto } from '@/modules/countries/types'
-import { PlayersPositionCombo } from '@/modules/player-positions/combo'
+import { mapCountriesListToComboOptions } from '@/modules/countries/utils'
 import { PlayerPositionDto } from '@/modules/player-positions/types'
+import { mapPositionsListToComboOptions } from '@/modules/player-positions/utils'
 import { FootedSelect } from '@/modules/players/footed-select'
-import { PlayersFiltersDto } from '@/modules/players/types'
-import { TeamsCombo } from '@/modules/teams/combo'
+import { PlayersFiltersState } from '@/modules/players/types'
 import { TeamBasicDataDto } from '@/modules/teams/types'
+import { mapTeamsListToComboOptions } from '@/modules/teams/utils'
 
 const StyledCheckboxContainer = styled('div')(() => ({
   display: 'flex',
@@ -30,8 +31,8 @@ interface IPlayersFilterFormProps {
   teamsData: TeamBasicDataDto[]
   competitionsData: CompetitionBasicDataDto[]
   competitionGroupsData: CompetitionGroupBasicDataDto[]
-  filters: PlayersFiltersDto
-  onFilter: (data: PlayersFiltersDto) => void
+  filters: PlayersFiltersState
+  onFilter: (data: PlayersFiltersState) => void
   onClearFilters: () => void
 }
 
@@ -91,33 +92,35 @@ export const PlayersFilterForm = ({
               </Grid>
             </Grid>
             <FootedSelect name="footed" label={t('FOOTED')} size="small" />
-            <CountriesCombo
-              name="countryIds"
-              data={countriesData}
+            <Combo
+              name="countries"
+              data={mapCountriesListToComboOptions(countriesData)}
               label={t('COUNTRIES')}
               multiple
             />
-            <PlayersPositionCombo
-              name="positionIds"
-              data={positionsData}
+            <Combo
+              name="positions"
+              data={mapPositionsListToComboOptions(positionsData)}
               label={t('POSITIONS')}
               multiple
             />
-            <TeamsCombo
-              data={teamsData}
-              name="teamIds"
+            <Combo
+              name="teams"
+              data={mapTeamsListToComboOptions(teamsData)}
               label={t('TEAM')}
               multiple
             />
-            <CompetitionsCombo
-              name="competitionIds"
-              data={competitionsData}
+            <Combo
+              name="competitions"
+              data={mapCompetitionsListToComboOptions(competitionsData)}
               label={t('COMPETITIONS')}
               multiple
             />
-            <CompetitionGroupsCombo
-              name="competitionGroupIds"
-              data={competitionGroupsData}
+            <Combo
+              name="competitionGroups"
+              data={mapCompetitionGroupsListToComboOptions(
+                competitionGroupsData,
+              )}
               label={t('COMPETITION_GROUPS')}
               multiple
             />

--- a/src/modules/players/forms/utils.ts
+++ b/src/modules/players/forms/utils.ts
@@ -6,8 +6,11 @@ import {
   CreatePlayerDto,
   Footed,
   PlayerDto,
+  PlayersFiltersDto,
+  PlayersFiltersState,
   UpdatePlayerDto,
 } from '@/modules/players/types'
+import { getIdsArray } from '@/utils/get-ids-array'
 import { validateId, validateIdsArray } from '@/utils/validation-helpers'
 
 export const initialValues: CreatePlayerDto = {
@@ -108,5 +111,27 @@ export function getInitialStateFromCurrent(player: PlayerDto): UpdatePlayerDto {
     countryId: country.id,
     primaryPositionId: primaryPosition.id,
     secondaryPositionIds: secondaryPositions?.map(pos => pos.id) || [],
+  }
+}
+
+export function mapFiltersStateToFilterDto(
+  input: PlayersFiltersState,
+): PlayersFiltersDto {
+  const {
+    countries,
+    positions,
+    teams,
+    competitionGroups,
+    competitions,
+    ...rest
+  } = input
+
+  return {
+    ...rest,
+    countryIds: getIdsArray(countries),
+    positionIds: getIdsArray(positions),
+    teamIds: getIdsArray(teams),
+    competitionIds: getIdsArray(competitions),
+    competitionGroupIds: getIdsArray(competitionGroups),
   }
 }

--- a/src/modules/players/types.ts
+++ b/src/modules/players/types.ts
@@ -1,3 +1,5 @@
+import { IComboOptions } from '@/components/combo/types'
+
 export type PlayerBasicDataDto = Components.Schemas.PlayerBasicDataDto
 export type PlayerSuperBasicDataDto = Components.Schemas.PlayerSuperBasicDataDto
 
@@ -22,6 +24,21 @@ export type PlayersFiltersDto = Pick<
   | 'teamIds'
   | 'orderId'
 >
+
+export type PlayersFiltersState = Omit<
+  PlayersFiltersDto,
+  | 'countryIds'
+  | 'positionIds'
+  | 'teamIds'
+  | 'competitionIds'
+  | 'competitionGroupIds'
+> & {
+  countries: IComboOptions[]
+  positions: IComboOptions[]
+  teams: IComboOptions[]
+  competitions: IComboOptions[]
+  competitionGroups: IComboOptions[]
+}
 
 export type PlayersSortBy = Paths.PlayersControllerFindAll.Parameters.SortBy
 

--- a/src/modules/teams/utils.ts
+++ b/src/modules/teams/utils.ts
@@ -1,5 +1,17 @@
+import { IComboOptions } from '@/components/combo/types'
 import { Routes } from '@/utils/routes'
+
+import { TeamBasicDataDto } from './types'
 
 export function getSingleTeamRoute(slug: string) {
   return `${Routes.TEAMS}/${slug}`
+}
+
+export function mapTeamsListToComboOptions(
+  data: TeamBasicDataDto[],
+): IComboOptions[] {
+  return data.map(({ id, name }) => ({
+    id,
+    label: name,
+  }))
 }

--- a/src/pages/players/index.tsx
+++ b/src/pages/players/index.tsx
@@ -142,6 +142,8 @@ const PlayersPage = () => {
         onFilter={handleSetFilters}
         onClearFilters={() => handleSetFilters(initialFilters)}
       />
+      <h3>Applied filters:</h3>
+      <pre>{JSON.stringify(filters, null, 2)}</pre>
       <PlayersTable
         page={page}
         rowsPerPage={rowsPerPage}

--- a/src/pages/players/index.tsx
+++ b/src/pages/players/index.tsx
@@ -13,6 +13,7 @@ import { useCompetitionsList } from '@/modules/competitions/hooks'
 import { useCountriesList } from '@/modules/countries/hooks'
 import { usePlayerPositionsList } from '@/modules/player-positions/hooks'
 import { PlayersFilterForm } from '@/modules/players/forms/filter'
+import { mapFiltersStateToFilterDto } from '@/modules/players/forms/utils'
 import {
   useDeletePlayer,
   useLikePlayer,
@@ -21,7 +22,7 @@ import {
 } from '@/modules/players/hooks'
 import { PlayersTableRow } from '@/modules/players/table/row'
 import { PlayersTable } from '@/modules/players/table/table'
-import { PlayersFiltersDto, PlayersSortBy } from '@/modules/players/types'
+import { PlayersFiltersState, PlayersSortBy } from '@/modules/players/types'
 import { useTeamsList } from '@/modules/teams/hooks'
 import { useLocalStorage } from '@/utils/hooks/use-local-storage'
 import { useTable } from '@/utils/hooks/use-table'
@@ -49,16 +50,16 @@ export const getServerSideProps = withSessionSsr(
   },
 )
 
-const initialFilters: PlayersFiltersDto = {
+const initialFilters: PlayersFiltersState = {
   name: '',
   bornAfter: 1980,
   bornBefore: 2005,
   footed: '',
-  competitionGroupIds: [],
-  competitionIds: [],
-  countryIds: [],
-  positionIds: [],
-  teamIds: [],
+  countries: [],
+  positions: [],
+  teams: [],
+  competitions: [],
+  competitionGroups: [],
   isLiked: false,
 }
 
@@ -83,12 +84,12 @@ const PlayersPage = () => {
     handleSort,
   } = useTable('players-table')
 
-  const [filters, setFilters] = useLocalStorage<PlayersFiltersDto>({
+  const [filters, setFilters] = useLocalStorage({
     key: 'players-filters',
     initialValue: initialFilters,
   })
 
-  function handleSetFilters(newFilters: PlayersFiltersDto) {
+  function handleSetFilters(newFilters: PlayersFiltersState) {
     setFilters(newFilters)
     handleChangePage(null, 0)
   }
@@ -107,7 +108,7 @@ const PlayersPage = () => {
     limit: rowsPerPage,
     sortBy: sortBy as PlayersSortBy,
     sortingOrder: order,
-    ...filters,
+    ...mapFiltersStateToFilterDto(filters),
   })
 
   const { mutate: deletePlayer, isLoading: deletePlayerLoading } =

--- a/src/utils/get-ids-array.ts
+++ b/src/utils/get-ids-array.ts
@@ -1,0 +1,3 @@
+export function getIdsArray<T extends { id: string }>(input: T[]) {
+  return input.map(item => item.id)
+}


### PR DESCRIPTION
[SCOUT-163](https://playmakerpro.atlassian.net/browse/SCOUT-163)

### Task Description

- Create reusable `Combo` component that accepts an array of 

```
export interface IComboOptions {
  id: string
  label: string
}
```
 
- add utility functions - mostly mappers from list data to `IComboOptions` interface
- adjust the type of data we keep in filters state - for our combo components we used to keep just an array of ids. My proposal is to keep data with more context (satisfying `IComboOptions` type), so we can for example display array filters or do anything we want without doing some additional computing. Only thing we need to do is to map filters state to filters dto before we make an actual api request.

<img width="676" alt="Screenshot 2022-09-26 at 20 53 12" src="https://user-images.githubusercontent.com/55458549/192358095-c801fe35-4544-4c95-a18b-948fe2c4eee0.png">

<img width="469" alt="Screenshot 2022-09-26 at 20 53 21" src="https://user-images.githubusercontent.com/55458549/192358115-1494011d-9444-401c-90c0-a9b166020523.png">

- use `Combo` component and new filters strategy in `PlayersFilterForm` as a PoC 
 
### Additional Notes (optional)

<!-- Provide any additional notes: related PRs, screenshots, et al.). -->
