### PR TITLE
Feat/SCOUT-186-apply-filtered-groups

### DIFF
--- a/src/modules/notes/forms/filter.tsx
+++ b/src/modules/notes/forms/filter.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'next-i18next'
 
 import { FilterCombo } from '@/components/combo/combo'
 import { mapListDataToComboOptions } from '@/components/combo/utils'
+import FilteredCompetitonGroups from '@/components/filteredCompetitionGroups/filteredCompetitonGroups'
 import { FilterCheckboxContainer } from '@/components/forms/filter-checkbox-container'
 import { FilterFormActions } from '@/components/forms/filter-form-actions'
 import { FilterFormContainer } from '@/components/forms/filter-form-container'
@@ -47,6 +48,9 @@ export const NotesFilterForm = ({
   onClearFilters,
 }: INotesFilterFormProps) => {
   const { t } = useTranslation(['common', 'notes'])
+  const groupsComboData = mapCompetitionGroupsListToComboOptions(
+    competitionGroupsData,
+  )
 
   return (
     <Formik
@@ -57,7 +61,7 @@ export const NotesFilterForm = ({
       }}
       enableReinitialize
     >
-      {() => (
+      {({ values }) => (
         <Form autoComplete="off">
           <FilterFormContainer>
             <FilterCombo
@@ -122,14 +126,13 @@ export const NotesFilterForm = ({
               multiple
               size="small"
             />
-            <FilterCombo
+            <FilteredCompetitonGroups
+              competitionGroupsData={groupsComboData}
+              competitionsFormValues={values.competitionIds}
               name="competitionGroupIds"
-              data={mapCompetitionGroupsListToComboOptions(
-                competitionGroupsData,
-              )}
               label={t('COMPETITION_GROUPS')}
-              multiple
               size="small"
+              multiple
             />
             <RatingRangeSelect
               name="ratingRange"

--- a/src/modules/players/forms/filter.tsx
+++ b/src/modules/players/forms/filter.tsx
@@ -128,8 +128,8 @@ export const PlayersFilterForm = ({
             <FilteredCompetitonGroups
               competitionGroupsData={groupsComboData}
               competitionsFormValues={values.competitionIds}
-              name="competitionGroupsIds"
-              label={t('COMPETITIONS')}
+              name="competitionGroupIds"
+              label={t('COMPETITION_GROUPS')}
               size="small"
               multiple
             />

--- a/src/modules/reports/forms/filter.tsx
+++ b/src/modules/reports/forms/filter.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'next-i18next'
 
 import { FilterCombo } from '@/components/combo/combo'
 import { mapListDataToComboOptions } from '@/components/combo/utils'
+import FilteredCompetitonGroups from '@/components/filteredCompetitionGroups/filteredCompetitonGroups'
 import { FilterCheckboxContainer } from '@/components/forms/filter-checkbox-container'
 import { FilterFormActions } from '@/components/forms/filter-form-actions'
 import { FilterFormContainer } from '@/components/forms/filter-form-container'
@@ -47,6 +48,9 @@ export const ReportsFilterForm = ({
   onClearFilters,
 }: IReportsFilterFormProps) => {
   const { t } = useTranslation(['common', 'reports'])
+  const groupsComboData = mapCompetitionGroupsListToComboOptions(
+    competitionGroupsData,
+  )
 
   return (
     <Formik
@@ -57,7 +61,7 @@ export const ReportsFilterForm = ({
       }}
       enableReinitialize
     >
-      {() => (
+      {({ values }) => (
         <Form autoComplete="off">
           <FilterFormContainer>
             <FilterCombo
@@ -122,14 +126,13 @@ export const ReportsFilterForm = ({
               multiple
               size="small"
             />
-            <FilterCombo
+            <FilteredCompetitonGroups
+              competitionGroupsData={groupsComboData}
+              competitionsFormValues={values.competitionIds}
               name="competitionGroupIds"
-              data={mapCompetitionGroupsListToComboOptions(
-                competitionGroupsData,
-              )}
               label={t('COMPETITION_GROUPS')}
-              multiple
               size="small"
+              multiple
             />
             <RatingRangeSelect
               name="ratingRange"


### PR DESCRIPTION
### Task Description

[SCOUT-186](https://playmakerpro.atlassian.net/browse/SCOUT-186?atlOrigin=eyJpIjoiMTkxZTcyMTkzNWQ4NDA3YWFmYjZkMWUyNjQyNjVmZmEiLCJwIjoiaiJ9) (comment)

- added filtered competition groups on notes and reports filters
- fixedup filtered competition groups on players
