### PR TITLE
[SCOUT-329] general position

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -232,6 +232,6 @@
   "UNASSIGNED": "Unassigned",
   "GROUP": "Group",
   "LEAVE_PAGE_PROMPT": "Are you sure you want to leave this page?",
-  "POSITION_TYPE": "Position",
-  "POSITION_TYPES": "Positions"
+  "POSITION_TYPE": "General position",
+  "POSITION_TYPES": "General positions"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -231,5 +231,7 @@
   "LIKED_PLAYERS": "Liked players",
   "UNASSIGNED": "Unassigned",
   "GROUP": "Group",
-  "LEAVE_PAGE_PROMPT": "Are you sure you want to leave this page?"
+  "LEAVE_PAGE_PROMPT": "Are you sure you want to leave this page?",
+  "POSITION_TYPE": "Position",
+  "POSITION_TYPES": "Positions"
 }

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -234,6 +234,6 @@
   "UNASSIGNED": "Nieprzypisani",
   "GROUP": "Grupa",
   "LEAVE_PAGE_PROMPT": "Czy na pewno chcesz opuścić tą stronę?",
-  "POSITION_TYPE": "Pozycja ogólne",
+  "POSITION_TYPE": "Pozycja ogólna",
   "POSITION_TYPES": "Pozycje ogólne"
 }

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -234,6 +234,6 @@
   "UNASSIGNED": "Nieprzypisani",
   "GROUP": "Grupa",
   "LEAVE_PAGE_PROMPT": "Czy na pewno chcesz opuścić tą stronę?",
-  "POSITION_TYPE": "Pozycja",
-  "POSITION_TYPES": "Pozycje"
+  "POSITION_TYPE": "Pozycja ogólne",
+  "POSITION_TYPES": "Pozycje ogólne"
 }

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -233,5 +233,7 @@
   "LIKED_PLAYERS": "Polubieni zawodnicy",
   "UNASSIGNED": "Nieprzypisani",
   "GROUP": "Grupa",
-  "LEAVE_PAGE_PROMPT": "Czy na pewno chcesz opuścić tą stronę?"
+  "LEAVE_PAGE_PROMPT": "Czy na pewno chcesz opuścić tą stronę?",
+  "POSITION_TYPE": "Pozycja",
+  "POSITION_TYPES": "Pozycje"
 }

--- a/src/components/combo/utils.ts
+++ b/src/components/combo/utils.ts
@@ -41,5 +41,6 @@ export const mapFiltersStateToDto = (data: TFiltersStateData) => {
     )
       filtersDto[key] = (value as IComboOptions).id || ''
   })
+
   return filtersDto
 }

--- a/src/modules/insider-notes/forms/filter.tsx
+++ b/src/modules/insider-notes/forms/filter.tsx
@@ -11,8 +11,8 @@ import { CompetitionGroupBasicDataDto } from '@/modules/competition-groups/types
 import { mapCompetitionGroupsListToComboOptions } from '@/modules/competition-groups/utils'
 import { CompetitionBasicDataDto } from '@/modules/competitions/types'
 import { mapCompetitionsListToComboOptions } from '@/modules/competitions/utils'
-import { PlayerPositionDto } from '@/modules/player-positions/types'
-import { mapPlayerPositionsToComboOptions } from '@/modules/player-positions/utils'
+import { PlayerPositionTypeDto } from '@/modules/player-position-types/types'
+import { mapPlayerPositionTypesToComboOptions } from '@/modules/player-position-types/utils'
 import { PlayerBasicDataDto } from '@/modules/players/types'
 import { mapPlayersListToComboOptions } from '@/modules/players/utils'
 import { TeamBasicDataDto } from '@/modules/teams/types'
@@ -27,7 +27,7 @@ interface IFilterFormProps {
   teamsData: TeamBasicDataDto[]
   competitionsData: CompetitionBasicDataDto[]
   competitionGroupsData: CompetitionGroupBasicDataDto[]
-  playerPositionsData: PlayerPositionDto[]
+  playerPositionTypesData: PlayerPositionTypeDto[]
 }
 
 export const InsiderNotesFilterForm = ({
@@ -38,7 +38,7 @@ export const InsiderNotesFilterForm = ({
   teamsData,
   competitionsData,
   competitionGroupsData,
-  playerPositionsData,
+  playerPositionTypesData,
 }: IFilterFormProps) => {
   const { t } = useTranslation()
 
@@ -63,9 +63,11 @@ export const InsiderNotesFilterForm = ({
               filterBeforeComma
             />
             <FilterCombo
-              data={mapPlayerPositionsToComboOptions(playerPositionsData)}
-              label={t('POSITIONS')}
-              name="positionIds"
+              data={mapPlayerPositionTypesToComboOptions(
+                playerPositionTypesData,
+              )}
+              label={t('POSITION_TYPES')}
+              name="positionTypeIds"
               size="small"
               multiple
             />

--- a/src/modules/insider-notes/types.ts
+++ b/src/modules/insider-notes/types.ts
@@ -1,4 +1,5 @@
 import { IComboOptions, IStandardComboOptions } from '@/components/combo/types'
+import { IPlayerPositionTypeComboOptions } from '@/modules/player-position-types/types'
 
 import { ICompetitionGroupComboOptions } from '../competition-groups/types'
 import { ICompetitionComboOptions } from '../competitions/types'
@@ -25,6 +26,7 @@ export type FindAllInsiderNotesParams = Pick<
   | 'sortBy'
   | 'sortingOrder'
   | 'teamIds'
+  | 'positionTypeIds'
 >
 
 export type InsiderNotesFiltersDto = Pick<
@@ -35,6 +37,7 @@ export type InsiderNotesFiltersDto = Pick<
   | 'playerIds'
   | 'positionIds'
   | 'teamIds'
+  | 'positionTypeIds'
 >
 
 export type InsiderNotesFiltersState = Omit<
@@ -44,11 +47,13 @@ export type InsiderNotesFiltersState = Omit<
   | 'playerIds'
   | 'positionIds'
   | 'teamIds'
+  | 'positionTypeIds'
 > & {
   competitionGroupIds: ICompetitionGroupComboOptions[]
   competitionIds: ICompetitionComboOptions[]
   playerIds: IPlayerComboOptions[]
   positionIds: IPlayerPositionComboOptions[]
+  positionTypeIds: IPlayerPositionTypeComboOptions[]
   teamIds: IStandardComboOptions[]
 }
 

--- a/src/modules/matches/utils.ts
+++ b/src/modules/matches/utils.ts
@@ -18,8 +18,9 @@ export function getMatchDisplayName({
   }`
 }
 
-export const getBasicMatchName = (match: MatchBasicDataDto) =>
-  `${match.homeTeam.name} vs ${match.awayTeam.name}`
+export const getBasicMatchName = (
+  match: Omit<MatchBasicDataDto, 'competition'>,
+) => `${match.homeTeam.name} vs ${match.awayTeam.name}`
 
 export function getMatchResult(homeGoals?: number, awayGoals?: number) {
   if (!homeGoals || !awayGoals) {

--- a/src/modules/notes/details-card.tsx
+++ b/src/modules/notes/details-card.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'next-i18next'
 
 import { CardItemBasic } from '@/components/details-card/details-card-item'
 import { BallIcon, NotesIcon } from '@/components/icons'
+import { getPositionDisplayName } from '@/modules/player-positions/utils'
 import { formatDate } from '@/utils/format-date'
 
 import { getDocumentNumber } from '../../utils/get-document-number'
@@ -88,7 +89,9 @@ export const NoteDetailsCard = ({ note }: INoteDetailsCard) => {
           />
           <CardItemBasic
             title={t('notes:POSITION_PLAYED')}
-            value={meta?.position.name}
+            value={
+              meta?.position ? getPositionDisplayName(meta.position) : undefined
+            }
           />
           <CardItemBasic title={t('SHIRT_NO')} value={shirtNo?.toString()} />
           <CardItemBasic

--- a/src/modules/notes/forms/filter.tsx
+++ b/src/modules/notes/forms/filter.tsx
@@ -17,8 +17,8 @@ import { CompetitionBasicDataDto } from '@/modules/competitions/types'
 import { mapCompetitionsListToComboOptions } from '@/modules/competitions/utils'
 import { MatchBasicDataDto } from '@/modules/matches/types'
 import { mapMatchesListToComboOptions } from '@/modules/matches/utils'
-import { PlayerPositionDto } from '@/modules/player-positions/types'
-import { mapPlayerPositionsToComboOptions } from '@/modules/player-positions/utils'
+import { PlayerPositionTypeDto } from '@/modules/player-position-types/types'
+import { mapPlayerPositionTypesToComboOptions } from '@/modules/player-position-types/utils'
 import { PlayerBasicDataDto } from '@/modules/players/types'
 import { mapPlayersListToComboOptions } from '@/modules/players/utils'
 import { TeamBasicDataDto } from '@/modules/teams/types'
@@ -27,7 +27,7 @@ import { NotesFiltersState } from '../types'
 
 interface INotesFilterFormProps {
   playersData: PlayerBasicDataDto[]
-  positionsData: PlayerPositionDto[]
+  positionTypesData: PlayerPositionTypeDto[]
   teamsData: TeamBasicDataDto[]
   matchesData: MatchBasicDataDto[]
   competitionsData: CompetitionBasicDataDto[]
@@ -40,7 +40,7 @@ interface INotesFilterFormProps {
 export const NotesFilterForm = ({
   playersData,
   teamsData,
-  positionsData,
+  positionTypesData,
   competitionsData,
   competitionGroupsData,
   matchesData,
@@ -74,11 +74,11 @@ export const NotesFilterForm = ({
               filterBeforeComma
             />
             <FilterCombo
-              name="positionIds"
-              data={mapPlayerPositionsToComboOptions(positionsData)}
-              label={t('POSITIONS')}
-              multiple
+              name="positionTypeIds"
+              label={t('POSITION_TYPES')}
+              data={mapPlayerPositionTypesToComboOptions(positionTypesData)}
               size="small"
+              multiple
             />
             <FilterCombo
               data={mapListDataToComboOptions(teamsData)}

--- a/src/modules/notes/table/row.tsx
+++ b/src/modules/notes/table/row.tsx
@@ -30,6 +30,7 @@ import {
   getMatchDisplayName,
   getSingleMatchRoute,
 } from '@/modules/matches/utils'
+import { getPositionDisplayName } from '@/modules/player-positions/utils'
 import { getSinglePlayerRoute } from '@/modules/players/utils'
 import { IReportFromNoteQuery } from '@/modules/reports/types'
 import { formatDate } from '@/utils/format-date'
@@ -193,7 +194,9 @@ export const NotesTableRow = ({
         ) : (
           <StyledTableCell>-</StyledTableCell>
         )}
-        <StyledTableCell>{meta?.position?.name || '-'}</StyledTableCell>
+        <StyledTableCell>
+          {meta?.position ? getPositionDisplayName(meta.position) : '-'}
+        </StyledTableCell>
         <StyledTableCell>{`${author.firstName} ${author.lastName}`}</StyledTableCell>
         <StyledTableCell padding="checkbox" align="center">
           {observationType === 'LIVE' ? <LiveObservationIcon /> : <VideoIcon />}

--- a/src/modules/notes/types.ts
+++ b/src/modules/notes/types.ts
@@ -1,4 +1,5 @@
 import { IComboOptions, IStandardComboOptions } from '@/components/combo/types'
+import { IPlayerPositionTypeComboOptions } from '@/modules/player-position-types/types'
 
 import { ICompetitionGroupComboOptions } from '../competition-groups/types'
 import { ICompetitionComboOptions } from '../competitions/types'
@@ -22,6 +23,7 @@ export type FindAllNotesParams = Pick<
   | 'playerBornBefore'
   | 'playerIds'
   | 'positionIds'
+  | 'positionTypeIds'
   | 'sortBy'
   | 'sortingOrder'
   | 'teamIds'
@@ -45,6 +47,7 @@ export type NotesFiltersState = Omit<
   | 'matchIds'
   | 'playerIds'
   | 'positionIds'
+  | 'positionTypeIds'
   | 'teamIds'
   | 'observationType'
   | 'percentageRatingRanges'
@@ -56,6 +59,7 @@ export type NotesFiltersState = Omit<
   matchIds: IMatchComboOptions[]
   playerIds: IPlayerComboOptions[]
   positionIds: IPlayerPositionComboOptions[]
+  positionTypeIds: IPlayerPositionTypeComboOptions[]
   teamIds: IStandardComboOptions[]
   observationType: IComboOptions | null
   percentageRatingRanges: IComboOptions[]

--- a/src/modules/player-position-types/combo.tsx
+++ b/src/modules/player-position-types/combo.tsx
@@ -1,0 +1,54 @@
+import { AutocompleteRenderInputParams, TextField } from '@mui/material'
+import { Field } from 'formik'
+import { Autocomplete } from 'formik-mui'
+import { useTranslation } from 'next-i18next'
+
+import { IComboProps } from '@/types/combo'
+
+import { PlayerPositionTypeDto } from './types'
+
+interface IPlayersPositionTypesComboProps
+  extends IComboProps<PlayerPositionTypeDto> {}
+
+export const PlayersPositionTypeCombo = ({
+  data,
+  name,
+  label,
+  multiple,
+  size,
+  error,
+  helperText,
+}: IPlayersPositionTypesComboProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Field
+      name={name}
+      component={Autocomplete}
+      multiple={multiple}
+      id={name}
+      size={size}
+      options={['', ...data.map(type => type.id)]}
+      getOptionLabel={(option: string) => {
+        if (option === '') {
+          return ''
+        }
+        const type = data.find(p => p.id === option)
+        if (type) {
+          return type.name
+        }
+        return t('NONE')
+      }}
+      filterSelectedOptions
+      renderInput={(params: AutocompleteRenderInputParams) => (
+        <TextField
+          {...params}
+          error={error}
+          helperText={helperText}
+          label={label || t('POSITION_TYPE')}
+          placeholder={label || t('POSITION_TYPE')}
+        />
+      )}
+    />
+  )
+}

--- a/src/modules/player-position-types/hooks.ts
+++ b/src/modules/player-position-types/hooks.ts
@@ -1,0 +1,50 @@
+import {
+  createPlayerPositionType,
+  deletePlayerPositionType,
+  getPlayerPositionTypes,
+  getPlayerPositionTypesList,
+  updatePlayerPositionType,
+} from '@/services/api/methods/player-position-types'
+import { TModuleName } from '@/services/api/modules'
+import { useCreateDocument } from '@/utils/hooks/api/use-create-document'
+import { useDeleteDocument } from '@/utils/hooks/api/use-delete-document'
+import { useList } from '@/utils/hooks/api/use-list'
+import { usePaginatedData } from '@/utils/hooks/api/use-paginated-data'
+import { useUpdateDocument } from '@/utils/hooks/api/use-update-document'
+
+import {
+  CreatePlayerPostitionTypeDto,
+  FindAllPlayerPositionsTypesParams,
+  PlayerPositionTypeDto,
+  UpdatePlayerPostitionTypeDto,
+} from './types'
+
+const moduleName: TModuleName = 'player-position-types'
+
+export const usePlayerPositionTypesList = () =>
+  useList<PlayerPositionTypeDto>(moduleName, getPlayerPositionTypesList)
+
+export const usePlayerPositionTypes = (
+  params: FindAllPlayerPositionsTypesParams,
+) =>
+  usePaginatedData<FindAllPlayerPositionsTypesParams, PlayerPositionTypeDto>(
+    moduleName,
+    params,
+    getPlayerPositionTypes,
+  )
+
+export const useUpdatePlayerPositionType = (id: string) =>
+  useUpdateDocument<UpdatePlayerPostitionTypeDto, PlayerPositionTypeDto>(
+    moduleName,
+    id,
+    updatePlayerPositionType,
+  )
+
+export const useDeletePlayerPositionType = () =>
+  useDeleteDocument<PlayerPositionTypeDto>(moduleName, deletePlayerPositionType)
+
+export const useCreatePlayerPosition = () =>
+  useCreateDocument<CreatePlayerPostitionTypeDto, PlayerPositionTypeDto>(
+    moduleName,
+    createPlayerPositionType,
+  )

--- a/src/modules/player-position-types/types.ts
+++ b/src/modules/player-position-types/types.ts
@@ -1,0 +1,27 @@
+import { IComboOptions } from '@/components/combo/types'
+
+export type PlayerPositionTypeDto = Components.Schemas.PlayerPositionTypeDto
+
+export type CreatePlayerPostitionTypeDto =
+  Components.Schemas.CreatePlayerPositionTypeDto
+
+export type UpdatePlayerPostitionTypeDto =
+  Components.Schemas.UpdatePlayerPositionTypeDto
+
+export type FindAllPlayerPositionsTypesParams = Pick<
+  Paths.PlayerPositionTypesControllerFindAll.QueryParameters,
+  'code' | 'limit' | 'name' | 'page' | 'sortBy' | 'sortingOrder'
+>
+
+export type PlayerPositionsTypesFiltersDto = Pick<
+  FindAllPlayerPositionsTypesParams,
+  'code' | 'name'
+>
+
+export type PlayerPositionTypesSortBy =
+  Paths.PlayerPositionTypesControllerFindAll.Parameters.SortBy
+
+export interface IPlayerPositionComboOptions extends IComboOptions {
+  name: string
+  code: string
+}

--- a/src/modules/player-position-types/types.ts
+++ b/src/modules/player-position-types/types.ts
@@ -21,7 +21,7 @@ export type PlayerPositionsTypesFiltersDto = Pick<
 export type PlayerPositionTypesSortBy =
   Paths.PlayerPositionTypesControllerFindAll.Parameters.SortBy
 
-export interface IPlayerPositionComboOptions extends IComboOptions {
+export interface IPlayerPositionTypeComboOptions extends IComboOptions {
   name: string
   code: string
 }

--- a/src/modules/player-position-types/utils.ts
+++ b/src/modules/player-position-types/utils.ts
@@ -1,0 +1,12 @@
+import { IPlayerPositionTypeComboOptions, PlayerPositionTypeDto } from './types'
+
+export function mapPlayerPositionTypesToComboOptions(
+  data: PlayerPositionTypeDto[],
+): IPlayerPositionTypeComboOptions[] {
+  return data.map(({ id, name, code }) => ({
+    id,
+    label: name,
+    name,
+    code,
+  }))
+}

--- a/src/modules/player-positions/forms/create.tsx
+++ b/src/modules/player-positions/forms/create.tsx
@@ -3,21 +3,26 @@ import { Field, Form, Formik } from 'formik'
 import filter from 'just-filter-object'
 import { useTranslation } from 'next-i18next'
 
+import { BasicCombo } from '@/components/combo/basicCombo'
+import { mapListDataToComboOptions } from '@/components/combo/utils'
 import { Container } from '@/components/forms/container'
 import { MainFormActions } from '@/components/forms/main-form-actions'
 import { useAlertsState } from '@/context/alerts/useAlertsState'
+import { PlayerPositionTypeDto } from '@/modules/player-position-types/types'
 
 import { CreatePlayerPostitionDto } from '../types'
 import { generateCreateValidationSchema, initialValues } from './utils'
 
 interface ICreateFormProps {
   onSubmit: (data: CreatePlayerPostitionDto) => void
+  positionTypesData: PlayerPositionTypeDto[]
   onCancelClick?: () => void
   fullwidth?: boolean
 }
 
 export const CreatePlayerPositionForm = ({
   onSubmit,
+  positionTypesData,
   onCancelClick,
   fullwidth,
 }: ICreateFormProps) => {
@@ -55,6 +60,19 @@ export const CreatePlayerPositionForm = ({
               label={t('CODE')}
               error={touched.code && !!errors.code}
               helperText={touched.code && errors.code}
+            />
+            <BasicCombo
+              data={mapListDataToComboOptions(positionTypesData)}
+              name="playerPositionTypeId"
+              label={t('POSITION_TYPE')}
+              error={
+                touched.playerPositionTypeId && !!errors.playerPositionTypeId
+              }
+              helperText={
+                touched.playerPositionTypeId
+                  ? errors.playerPositionTypeId
+                  : undefined
+              }
             />
             <MainFormActions
               label={t('POSITION')}

--- a/src/modules/player-positions/forms/edit.tsx
+++ b/src/modules/player-positions/forms/edit.tsx
@@ -4,9 +4,12 @@ import { Field, Form, Formik } from 'formik'
 import filter from 'just-filter-object'
 import { useTranslation } from 'next-i18next'
 
+import { BasicCombo } from '@/components/combo/basicCombo'
+import { mapListDataToComboOptions } from '@/components/combo/utils'
 import { Container } from '@/components/forms/container'
 import { MainFormActions } from '@/components/forms/main-form-actions'
 import { useAlertsState } from '@/context/alerts/useAlertsState'
+import { PlayerPositionTypeDto } from '@/modules/player-position-types/types'
 
 import { PlayerPositionDto, UpdatePlayerPostitionDto } from '../types'
 import {
@@ -16,6 +19,7 @@ import {
 
 interface IEditFormProps {
   current: PlayerPositionDto
+  positionTypesData: PlayerPositionTypeDto[]
   onSubmit: (data: UpdatePlayerPostitionDto) => void
   onCancelClick?: () => void
   fullwidth?: boolean
@@ -23,6 +27,7 @@ interface IEditFormProps {
 
 export const EditPlayerPositionForm = ({
   current,
+  positionTypesData,
   onSubmit,
   onCancelClick,
   fullwidth,
@@ -65,6 +70,19 @@ export const EditPlayerPositionForm = ({
               label={t('CODE')}
               error={touched.code && !!errors.code}
               helperText={touched.code && errors.code}
+            />
+            <BasicCombo
+              data={mapListDataToComboOptions(positionTypesData)}
+              name="playerPositionTypeId"
+              label={t('POSITION_TYPE')}
+              error={
+                touched.playerPositionTypeId && !!errors.playerPositionTypeId
+              }
+              helperText={
+                touched.playerPositionTypeId
+                  ? errors.playerPositionTypeId
+                  : undefined
+              }
             />
             <MainFormActions
               label={t('POSITION')}

--- a/src/modules/player-positions/forms/utils.ts
+++ b/src/modules/player-positions/forms/utils.ts
@@ -11,6 +11,7 @@ import {
 export const initialValues: CreatePlayerPostitionDto = {
   name: '',
   code: '',
+  playerPositionTypeId: '',
 }
 
 export function generateCreateValidationSchema(t: TFunction) {
@@ -32,11 +33,12 @@ export function generateUpdateValidationSchema() {
 export function getInitialStateFromCurrent(
   position: PlayerPositionDto,
 ): UpdatePlayerPostitionDto {
-  const { name, code } = position
+  const { name, code, positionType } = position
 
   const values = {
     name,
     code,
+    playerPositionTypeId: positionType.id,
   }
 
   return map(values, value => value || '')

--- a/src/modules/player-positions/table/row.tsx
+++ b/src/modules/player-positions/table/row.tsx
@@ -28,7 +28,7 @@ export const PlayerPositionsTableRow = ({
     handleMenuAction,
   } = useTableMenu()
 
-  const { id, name, code } = data
+  const { id, name, code, positionType } = data
 
   return (
     <StyledTableRow
@@ -50,6 +50,9 @@ export const PlayerPositionsTableRow = ({
       </StyledTableCell>
       <StyledTableCell>{name}</StyledTableCell>
       <StyledTableCell>{code}</StyledTableCell>
+      <StyledTableCell>
+        {positionType ? positionType.name : '-'}
+      </StyledTableCell>
     </StyledTableRow>
   )
 }

--- a/src/modules/player-positions/table/table.tsx
+++ b/src/modules/player-positions/table/table.tsx
@@ -16,6 +16,11 @@ function generateHeadCells(t: TFunction): IHeadCell[] {
   return [
     { id: 'name', label: t('NAME') },
     { id: 'code', label: t('CODE') },
+    {
+      id: 'playerPositionTypeId',
+      label: t('POSITION_TYPE'),
+      isSortingDisabled: true,
+    },
   ]
 }
 

--- a/src/modules/player-positions/utils.ts
+++ b/src/modules/player-positions/utils.ts
@@ -10,3 +10,9 @@ export function mapPlayerPositionsToComboOptions(
     code,
   }))
 }
+
+export function getPositionDisplayName(position: PlayerPositionDto) {
+  const { name, positionType } = position
+
+  return `${name}${positionType ? ` (${positionType.name})` : ''}`
+}

--- a/src/modules/players/details-card.tsx
+++ b/src/modules/players/details-card.tsx
@@ -3,6 +3,7 @@ import { Avatar, Card, CardContent, CardHeader, Grid } from '@mui/material'
 import { useTranslation } from 'next-i18next'
 
 import { CardItemBasic } from '@/components/details-card/details-card-item'
+import { getPositionDisplayName } from '@/modules/player-positions/utils'
 import { PlayerDto } from '@/modules/players/types'
 import { getFlagEmoji } from '@/utils/get-flag-emoji'
 
@@ -54,10 +55,13 @@ export const PlayerDetialsCard = ({ player }: IPlayerDetailsCard) => {
             value={teams[0]?.team.name}
             href={teams[0] ? `/teams/${teams[0].team.slug}` : undefined}
           />
-          <CardItemBasic title={t('POSITION')} value={primaryPosition.name} />
+          <CardItemBasic
+            title={t('POSITION')}
+            value={getPositionDisplayName(primaryPosition)}
+          />
           <CardItemBasic
             title={t('SECONDARY_POSITIONS')}
-            value={secondaryPositions.map(position => position.name).join(', ')}
+            value={secondaryPositions.map(getPositionDisplayName).join(', ')}
           />
           <CardItemBasic title={t('FOOTED')} value={t(footed)} />
           <CardItemBasic

--- a/src/modules/players/forms/filter.tsx
+++ b/src/modules/players/forms/filter.tsx
@@ -15,8 +15,8 @@ import { CompetitionBasicDataDto } from '@/modules/competitions/types'
 import { mapCompetitionsListToComboOptions } from '@/modules/competitions/utils'
 import { CountryDto } from '@/modules/countries/types'
 import { mapCountriesListToComboOptions } from '@/modules/countries/utils'
-import { PlayerPositionDto } from '@/modules/player-positions/types'
-import { mapPlayerPositionsToComboOptions } from '@/modules/player-positions/utils'
+import { PlayerPositionTypeDto } from '@/modules/player-position-types/types'
+import { mapPlayerPositionTypesToComboOptions } from '@/modules/player-position-types/utils'
 import { TeamBasicDataDto } from '@/modules/teams/types'
 
 import { getFootedComboData } from '../footed-select'
@@ -24,7 +24,7 @@ import { PlayersFiltersState } from '../types'
 
 interface IPlayersFilterFormProps {
   countriesData: CountryDto[]
-  positionsData: PlayerPositionDto[]
+  positionTypesData: PlayerPositionTypeDto[]
   teamsData: TeamBasicDataDto[]
   competitionsData: CompetitionBasicDataDto[]
   competitionGroupsData: CompetitionGroupBasicDataDto[]
@@ -36,7 +36,7 @@ interface IPlayersFilterFormProps {
 export const PlayersFilterForm = ({
   countriesData,
   teamsData,
-  positionsData,
+  positionTypesData,
   competitionsData,
   competitionGroupsData,
   filters,
@@ -105,9 +105,9 @@ export const PlayersFilterForm = ({
               multiple
             />
             <FilterCombo
-              name="positionIds"
-              data={mapPlayerPositionsToComboOptions(positionsData)}
-              label={t('POSITIONS')}
+              name="positionTypeIds"
+              data={mapPlayerPositionTypesToComboOptions(positionTypesData)}
+              label={t('POSITION_TYPES')}
               size="small"
               multiple
             />

--- a/src/modules/players/table/row.tsx
+++ b/src/modules/players/table/row.tsx
@@ -14,6 +14,7 @@ import { CellWithLink } from '@/components/tables/cell-with-link'
 import { TableMenu } from '@/components/tables/menu'
 import { TableMenuItem } from '@/components/tables/menu-item'
 import { StyledTableRow } from '@/components/tables/row'
+import { getPositionDisplayName } from '@/modules/player-positions/utils'
 import { getFlagEmoji } from '@/utils/get-flag-emoji'
 import { useTableMenu } from '@/utils/hooks/use-table-menu'
 
@@ -112,7 +113,9 @@ export const PlayersTableRow = ({
         label={teams[0]?.team?.name}
       />
       <StyledTableCell>{yearOfBirth}</StyledTableCell>
-      <StyledTableCell>{primaryPosition.name}</StyledTableCell>
+      <StyledTableCell>
+        {getPositionDisplayName(primaryPosition)}
+      </StyledTableCell>
       <StyledTableCell>{t(footed)}</StyledTableCell>
       <StyledTableCell align="center">
         <Badge badgeContent={count.reports || '0'} color="secondary">

--- a/src/modules/players/types.ts
+++ b/src/modules/players/types.ts
@@ -1,4 +1,5 @@
 import { IComboOptions, IStandardComboOptions } from '@/components/combo/types'
+import { IPlayerPositionTypeComboOptions } from '@/modules/player-position-types/types'
 
 import { ICompetitionGroupComboOptions } from '../competition-groups/types'
 import { ICompetitionComboOptions } from '../competitions/types'
@@ -26,6 +27,7 @@ export type PlayersFiltersDto = Pick<
   | 'footed'
   | 'name'
   | 'positionIds'
+  | 'positionTypeIds'
   | 'teamIds'
   | 'orderId'
   | 'hasNote'
@@ -37,6 +39,7 @@ export type PlayersFiltersState = Omit<
   PlayersFiltersDto,
   | 'countryIds'
   | 'positionIds'
+  | 'positionTypeIds'
   | 'teamIds'
   | 'competitionIds'
   | 'competitionGroupIds'
@@ -46,6 +49,7 @@ export type PlayersFiltersState = Omit<
 > & {
   countryIds: ICountryComboOptions[]
   positionIds: IPlayerPositionComboOptions[]
+  positionTypeIds: IPlayerPositionTypeComboOptions[]
   teamIds: IStandardComboOptions[]
   competitionIds: ICompetitionComboOptions[]
   competitionGroupIds: ICompetitionGroupComboOptions[]

--- a/src/modules/reports/forms/components/basic-details-card.tsx
+++ b/src/modules/reports/forms/components/basic-details-card.tsx
@@ -6,6 +6,7 @@ import {
   getMatchDisplayName,
   getSingleMatchRoute,
 } from '@/modules/matches/utils'
+import { getPositionDisplayName } from '@/modules/player-positions/utils'
 import {
   getPlayerFullName,
   getSinglePlayerRoute,
@@ -75,7 +76,7 @@ export const BasicDetailsCard = ({ report }: IReportBasicDetailsCard) => {
           />
           <CardItemBasic
             title={t('reports:POSITION_PLAYED')}
-            value={meta?.position.name}
+            value={meta ? getPositionDisplayName(meta.position) : undefined}
           />
           <CardItemBasic title={t('SHIRT_NO')} value={shirtNo} />
           <CardItemBasic

--- a/src/modules/reports/forms/filter.tsx
+++ b/src/modules/reports/forms/filter.tsx
@@ -17,8 +17,8 @@ import { CompetitionBasicDataDto } from '@/modules/competitions/types'
 import { mapCompetitionsListToComboOptions } from '@/modules/competitions/utils'
 import { MatchBasicDataDto } from '@/modules/matches/types'
 import { mapMatchesListToComboOptions } from '@/modules/matches/utils'
-import { PlayerPositionDto } from '@/modules/player-positions/types'
-import { mapPlayerPositionsToComboOptions } from '@/modules/player-positions/utils'
+import { PlayerPositionTypeDto } from '@/modules/player-position-types/types'
+import { mapPlayerPositionTypesToComboOptions } from '@/modules/player-position-types/utils'
 import { PlayerBasicDataDto } from '@/modules/players/types'
 import { mapPlayersListToComboOptions } from '@/modules/players/utils'
 import { TeamBasicDataDto } from '@/modules/teams/types'
@@ -27,7 +27,7 @@ import { ReportsFiltersState } from '../types'
 
 interface IReportsFilterFormProps {
   playersData: PlayerBasicDataDto[]
-  positionsData: PlayerPositionDto[]
+  positionTypesData: PlayerPositionTypeDto[]
   teamsData: TeamBasicDataDto[]
   matchesData: MatchBasicDataDto[]
   competitionsData: CompetitionBasicDataDto[]
@@ -40,7 +40,7 @@ interface IReportsFilterFormProps {
 export const ReportsFilterForm = ({
   playersData,
   teamsData,
-  positionsData,
+  positionTypesData,
   competitionsData,
   competitionGroupsData,
   matchesData,
@@ -100,9 +100,9 @@ export const ReportsFilterForm = ({
               </Grid>
             </Grid>
             <FilterCombo
-              name="positionIds"
-              data={mapPlayerPositionsToComboOptions(positionsData)}
-              label={t('POSITIONS')}
+              name="positionTypeIds"
+              data={mapPlayerPositionTypesToComboOptions(positionTypesData)}
+              label={t('POSITION_TYPES')}
               multiple
               size="small"
             />

--- a/src/modules/reports/table/row.tsx
+++ b/src/modules/reports/table/row.tsx
@@ -30,6 +30,7 @@ import {
   getMatchDisplayName,
   getSingleMatchRoute,
 } from '@/modules/matches/utils'
+import { getPositionDisplayName } from '@/modules/player-positions/utils'
 import {
   getPlayerFullName,
   getSinglePlayerRoute,
@@ -190,7 +191,9 @@ export const ReportsTableRow = ({
         ) : (
           <StyledTableCell>-</StyledTableCell>
         )}
-        <StyledTableCell>{meta?.position?.name || '-'}</StyledTableCell>
+        <StyledTableCell>
+          {meta?.position ? getPositionDisplayName(meta.position) : '-'}
+        </StyledTableCell>
         <StyledTableCell>{`${author.firstName} ${author.lastName}`}</StyledTableCell>
         <StyledTableCell padding="checkbox" align="center">
           {observationType === 'LIVE' ? <LiveObservationIcon /> : <VideoIcon />}

--- a/src/modules/reports/types.ts
+++ b/src/modules/reports/types.ts
@@ -1,4 +1,5 @@
 import { IComboOptions, IStandardComboOptions } from '@/components/combo/types'
+import { IPlayerPositionTypeComboOptions } from '@/modules/player-position-types/types'
 
 import { ICompetitionGroupComboOptions } from '../competition-groups/types'
 import { ICompetitionComboOptions } from '../competitions/types'
@@ -23,6 +24,7 @@ export type FindAllReportsParams = Pick<
   | 'playerBornBefore'
   | 'playerIds'
   | 'positionIds'
+  | 'positionTypeIds'
   | 'sortBy'
   | 'sortingOrder'
   | 'teamIds'
@@ -51,12 +53,14 @@ export type ReportsFiltersState = Omit<
   | 'percentageRatingRanges'
   | 'playerBornAfter'
   | 'playerBornBefore'
+  | 'positionTypeIds'
 > & {
   competitionGroupIds: ICompetitionGroupComboOptions[]
   competitionIds: ICompetitionComboOptions[]
   matchIds: IMatchComboOptions[]
   playerIds: IPlayerComboOptions[]
   positionIds: IPlayerPositionComboOptions[]
+  positionTypeIds: IPlayerPositionTypeComboOptions[]
   teamIds: IStandardComboOptions[]
   observationType: IComboOptions | null
   percentageRatingRanges: IComboOptions[]

--- a/src/pages/insider-notes/index.tsx
+++ b/src/pages/insider-notes/index.tsx
@@ -22,7 +22,7 @@ import {
   InsiderNotesFiltersState,
   InsiderNotesSortBy,
 } from '@/modules/insider-notes/types'
-import { usePlayerPositionsList } from '@/modules/player-positions/hooks'
+import { usePlayerPositionTypesList } from '@/modules/player-position-types/hooks'
 import { usePlayersList } from '@/modules/players/hooks'
 import { useTeamsList } from '@/modules/teams/hooks'
 import { getDocumentNumber } from '@/utils/get-document-number'
@@ -41,6 +41,7 @@ const initialFilters: InsiderNotesFiltersState = {
   isLiked: false,
   playerIds: [],
   positionIds: [],
+  positionTypeIds: [],
   teamIds: [],
 }
 
@@ -90,8 +91,10 @@ const InsiderNotesPage = ({ errorStatus, errorMessage }: TSsrRole) => {
     useCompetitionGroupsList()
   const { data: competitionsData, isLoading: competitionsLoading } =
     useCompetitionsList()
-  const { data: playerPositionsData, isLoading: playerPostitionsLoading } =
-    usePlayerPositionsList()
+  const {
+    data: playerPositionTypesData,
+    isLoading: playerPostitionTypesLoading,
+  } = usePlayerPositionTypesList()
   const { data: playersData, isLoading: playersLoading } = usePlayersList()
   const { data: teamsData, isLoading: teamsLoading } = useTeamsList()
 
@@ -110,11 +113,11 @@ const InsiderNotesPage = ({ errorStatus, errorMessage }: TSsrRole) => {
     deleteLoading ||
     competitionGroupsLoading ||
     competitionsLoading ||
-    playerPostitionsLoading ||
     playersLoading ||
     teamsLoading ||
     likeLoading ||
-    unLikeLoading
+    unLikeLoading ||
+    playerPostitionTypesLoading
 
   if (errorStatus)
     return <ErrorContent message={errorMessage} status={errorStatus} />
@@ -129,7 +132,7 @@ const InsiderNotesPage = ({ errorStatus, errorMessage }: TSsrRole) => {
           onClearFilters={() => handleSetFilters(initialFilters)}
           competitionGroupsData={competitionGroupsData || []}
           competitionsData={competitionsData || []}
-          playerPositionsData={playerPositionsData || []}
+          playerPositionTypesData={playerPositionTypesData || []}
           playersData={playersData || []}
           teamsData={teamsData || []}
         />

--- a/src/pages/notes/index.tsx
+++ b/src/pages/notes/index.tsx
@@ -15,7 +15,7 @@ import { useDeleteNote, useNotes, useUnlikeNote } from '@/modules/notes/hooks'
 import { NotesTable } from '@/modules/notes/table/table'
 import { NotesFiltersState, NotesSortBy } from '@/modules/notes/types'
 import { useOnLikeNoteClick } from '@/modules/notes/utils'
-import { usePlayerPositionsList } from '@/modules/player-positions/hooks'
+import { usePlayerPositionTypesList } from '@/modules/player-position-types/hooks'
 import { usePlayersList } from '@/modules/players/hooks'
 import { useTeamsList } from '@/modules/teams/hooks'
 import { getDocumentNumber } from '@/utils/get-document-number'
@@ -34,6 +34,7 @@ const initialFilters: NotesFiltersState = {
   playerBornBefore: '',
   playerIds: [],
   positionIds: [],
+  positionTypeIds: [],
   teamIds: [],
   observationType: null,
   onlyLikedPlayers: false,
@@ -84,8 +85,8 @@ const NotesPage = () => {
   const { data: players, isLoading: playersLoading } = usePlayersList({
     isLiked: filters.onlyLikedPlayers,
   })
-  const { data: positions, isLoading: positionsLoading } =
-    usePlayerPositionsList()
+  const { data: positionTypes, isLoading: positionTypesLoading } =
+    usePlayerPositionTypesList()
 
   const { data: notes, isLoading: notesLoading } = useNotes({
     page: page + 1,
@@ -117,10 +118,10 @@ const NotesPage = () => {
     deleteNoteLoading ||
     matchesLoading ||
     playersLoading ||
-    positionsLoading ||
     likeNoteLoading ||
     unlikeNoteLoading ||
-    likeNoteLoading
+    likeNoteLoading ||
+    positionTypesLoading
 
   return (
     <>
@@ -131,7 +132,7 @@ const NotesPage = () => {
           filters={filters}
           matchesData={matches || []}
           playersData={players || []}
-          positionsData={positions || []}
+          positionTypesData={positionTypes || []}
           teamsData={teams || []}
           competitionsData={competitions || []}
           competitionGroupsData={competitionGroups || []}

--- a/src/pages/player-positions/create.tsx
+++ b/src/pages/player-positions/create.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'next-i18next'
 import { ErrorContent } from '@/components/error/error-content'
 import { Loader } from '@/components/loader/loader'
 import { PageHeading } from '@/components/page-heading/page-heading'
+import { usePlayerPositionTypesList } from '@/modules/player-position-types/hooks'
 import { CreatePlayerPositionForm } from '@/modules/player-positions/forms/create'
 import { useCreatePlayerPosition } from '@/modules/player-positions/hooks'
 import { TSsrRole, withSessionSsrRole } from '@/utils/withSessionSsrRole'
@@ -17,14 +18,21 @@ const CreatePlayerPositionPage = ({ errorMessage, errorStatus }: TSsrRole) => {
 
   const { mutate: createPlayerPosition, isLoading: createLoading } =
     useCreatePlayerPosition()
+  const positionTypes = usePlayerPositionTypesList()
 
   if (errorStatus)
     return <ErrorContent message={errorMessage} status={errorStatus} />
+
+  const isLoading = createLoading || positionTypes.isLoading
+
   return (
     <>
-      {createLoading && <Loader />}
+      {isLoading && <Loader />}
       <PageHeading title={t('player-positions:CREATE_PAGE_TITLE')} />
-      <CreatePlayerPositionForm onSubmit={createPlayerPosition} />
+      <CreatePlayerPositionForm
+        onSubmit={createPlayerPosition}
+        positionTypesData={positionTypes.data || []}
+      />
     </>
   )
 }

--- a/src/pages/player-positions/edit/[id].tsx
+++ b/src/pages/player-positions/edit/[id].tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'next-i18next'
 import { ErrorContent } from '@/components/error/error-content'
 import { Loader } from '@/components/loader/loader'
 import { PageHeading } from '@/components/page-heading/page-heading'
+import { usePlayerPositionTypesList } from '@/modules/player-position-types/hooks'
 import { EditPlayerPositionForm } from '@/modules/player-positions/forms/edit'
 import { useUpdatePlayerPosition } from '@/modules/player-positions/hooks'
 import { PlayerPositionDto } from '@/modules/player-positions/types'
@@ -36,13 +37,22 @@ const EditPlayerPositionPage = ({
   const { mutate: updatePlayerPosition, isLoading: updateLoading } =
     useUpdatePlayerPosition(data?.id || '')
 
+  const positionTypes = usePlayerPositionTypesList()
+
   if (!data || errorStatus)
     return <ErrorContent message={errorMessage} status={errorStatus} />
+
+  const isLoading = updateLoading || positionTypes.isLoading
+
   return (
     <>
-      {updateLoading && <Loader />}
+      {isLoading && <Loader />}
       <PageHeading title={t('player-positions:EDIT_PAGE_TITLE')} />
-      <EditPlayerPositionForm current={data} onSubmit={updatePlayerPosition} />
+      <EditPlayerPositionForm
+        current={data}
+        onSubmit={updatePlayerPosition}
+        positionTypesData={positionTypes.data || []}
+      />
     </>
   )
 }

--- a/src/pages/players/index.tsx
+++ b/src/pages/players/index.tsx
@@ -11,7 +11,7 @@ import { PageHeading } from '@/components/page-heading/page-heading'
 import { useCompetitionGroupsList } from '@/modules/competition-groups/hooks'
 import { useCompetitionsList } from '@/modules/competitions/hooks'
 import { useCountriesList } from '@/modules/countries/hooks'
-import { usePlayerPositionsList } from '@/modules/player-positions/hooks'
+import { usePlayerPositionTypesList } from '@/modules/player-position-types/hooks'
 import { PlayersFilterForm } from '@/modules/players/forms/filter'
 import {
   useDeletePlayer,
@@ -41,6 +41,7 @@ const initialFilters: PlayersFiltersState = {
   competitionIds: [],
   countryIds: [],
   positionIds: [],
+  positionTypeIds: [],
   teamIds: [],
   isLiked: false,
   hasNote: false,
@@ -88,8 +89,8 @@ const PlayersPage = () => {
     useCompetitionsList()
   const { data: competitionGroups, isLoading: competitionGroupsLoading } =
     useCompetitionGroupsList()
-  const { data: positions, isLoading: positionsLoading } =
-    usePlayerPositionsList()
+  const { data: positionTypes, isLoading: positionTypesLoading } =
+    usePlayerPositionTypesList()
 
   const { data: players, isLoading: playersLoading } = usePlayers({
     page: page + 1,
@@ -124,7 +125,7 @@ const PlayersPage = () => {
     playersLoading ||
     likePlayerLoading ||
     unlikePlayerLoading ||
-    positionsLoading
+    positionTypesLoading
 
   return (
     <>
@@ -134,7 +135,7 @@ const PlayersPage = () => {
         <PlayersFilterForm
           filters={filters}
           countriesData={countries || []}
-          positionsData={positions || []}
+          positionTypesData={positionTypes || []}
           competitionsData={competitions || []}
           competitionGroupsData={competitionGroups || []}
           teamsData={teams || []}

--- a/src/pages/reports/index.tsx
+++ b/src/pages/reports/index.tsx
@@ -10,7 +10,7 @@ import { PageHeading } from '@/components/page-heading/page-heading'
 import { useCompetitionGroupsList } from '@/modules/competition-groups/hooks'
 import { useCompetitionsList } from '@/modules/competitions/hooks'
 import { useMatchesList } from '@/modules/matches/hooks'
-import { usePlayerPositionsList } from '@/modules/player-positions/hooks'
+import { usePlayerPositionTypesList } from '@/modules/player-position-types/hooks'
 import { usePlayersList } from '@/modules/players/hooks'
 import { ReportsFilterForm } from '@/modules/reports/forms/filter'
 import {
@@ -42,6 +42,7 @@ const initialFilters: ReportsFiltersState = {
   playerBornBefore: '',
   playerIds: [],
   positionIds: [],
+  positionTypeIds: [],
   teamIds: [],
   hasVideo: false,
   observationType: null,
@@ -94,8 +95,8 @@ const ReportsPage = () => {
   const { data: players, isLoading: playersLoading } = usePlayersList({
     isLiked: filters.onlyLikedPlayers,
   })
-  const { data: positions, isLoading: positionsLoading } =
-    usePlayerPositionsList()
+  const { data: positionTypes, isLoading: positionTypesLoading } =
+    usePlayerPositionTypesList()
 
   const { data: reports, isLoading: reportsLoading } = useReports({
     page: page + 1,
@@ -129,9 +130,9 @@ const ReportsPage = () => {
     deleteReportLoading ||
     matchesLoading ||
     playersLoading ||
-    positionsLoading ||
     likeReportLoading ||
-    unlikeReportLoading
+    unlikeReportLoading ||
+    positionTypesLoading
 
   return (
     <>
@@ -142,7 +143,7 @@ const ReportsPage = () => {
           filters={filters}
           matchesData={matches || []}
           playersData={players || []}
-          positionsData={positions || []}
+          positionTypesData={positionTypes || []}
           teamsData={teams || []}
           competitionsData={competitions || []}
           competitionGroupsData={competitionGroups || []}

--- a/src/services/api/methods/player-position-types.ts
+++ b/src/services/api/methods/player-position-types.ts
@@ -1,0 +1,52 @@
+import {
+  CreatePlayerPostitionTypeDto,
+  FindAllPlayerPositionsTypesParams,
+  PlayerPositionTypeDto,
+  UpdatePlayerPostitionTypeDto,
+} from '@/modules/player-position-types/types'
+import { TModuleName } from '@/services/api/modules'
+
+import {
+  createDocument,
+  deleteDocument,
+  getAssetById,
+  getDataList,
+  getPaginatedData,
+  updateDocument,
+} from './helpers'
+
+const moduleName: TModuleName = 'player-position-types'
+
+export const getPlayerPositionTypesList = () =>
+  getDataList<PlayerPositionTypeDto>(moduleName)
+
+export const getPlayerPositionTypes = (
+  params: FindAllPlayerPositionsTypesParams,
+) =>
+  getPaginatedData<FindAllPlayerPositionsTypesParams, PlayerPositionTypeDto>(
+    params,
+    moduleName,
+  )
+
+export const createPlayerPositionType = (data: CreatePlayerPostitionTypeDto) =>
+  createDocument<CreatePlayerPostitionTypeDto, PlayerPositionTypeDto>(
+    data,
+    moduleName,
+  )
+
+interface IUpdateArgs {
+  id: string
+  data: UpdatePlayerPostitionTypeDto
+}
+export const updatePlayerPositionType = ({ id, data }: IUpdateArgs) =>
+  updateDocument<UpdatePlayerPostitionTypeDto, PlayerPositionTypeDto>(
+    id,
+    data,
+    moduleName,
+  )
+
+export const getPlayerPositionTypeById = (id: string, token?: string) =>
+  getAssetById<PlayerPositionTypeDto>({ moduleName, id, token })
+
+export const deletePlayerPositionType = (id: string) =>
+  deleteDocument<PlayerPositionTypeDto>(id, moduleName)

--- a/src/services/api/modules.ts
+++ b/src/services/api/modules.ts
@@ -38,3 +38,4 @@ export type TModuleName =
   | 'user-insider-note-acl'
   | 'organization-insider-note-acl'
   | 'dashboard'
+  | 'player-position-types'

--- a/src/types/generated.d.ts
+++ b/src/types/generated.d.ts
@@ -291,6 +291,12 @@ declare namespace Components {
             id?: string;
             name: string;
             code: string;
+            playerPositionTypeId: string;
+        }
+        export interface CreatePlayerPositionTypeDto {
+            id?: string;
+            name: string;
+            code: string;
         }
         export interface CreatePlayerStatsDto {
             id?: string;
@@ -445,6 +451,12 @@ declare namespace Components {
             topReports?: DashboardReportDto[];
             topPlayers?: DashboardPlayerDto[];
         }
+        export interface DashboardMatchDto {
+            id: string;
+            date: string; // date-time
+            homeTeam: TeamBasicDataDto;
+            awayTeam: TeamBasicDataDto;
+        }
         export interface DashboardNoteDto {
             player?: PlayerSuperBasicDataDto;
             id: string;
@@ -479,11 +491,11 @@ declare namespace Components {
             _count: Count;
         }
         export interface DashboardReportDto {
+            match: DashboardMatchDto;
             id: string;
             player: PlayerSuperBasicDataDto;
             createdAt: string; // date-time
             finalRating?: number;
-            match?: MatchBasicDataDto;
             docNumber: number;
         }
         export interface DashboardTeamAffiliationDto {
@@ -780,6 +792,12 @@ declare namespace Components {
             _count: Count;
         }
         export interface PlayerPositionDto {
+            id: string;
+            name: string;
+            code: string;
+            positionType: PlayerPositionTypeDto;
+        }
+        export interface PlayerPositionTypeDto {
             id: string;
             name: string;
             code: string;
@@ -1129,6 +1147,11 @@ declare namespace Components {
             isPublic?: boolean;
         }
         export interface UpdatePlayerPositionDto {
+            name?: string;
+            code?: string;
+            playerPositionTypeId?: string;
+        }
+        export interface UpdatePlayerPositionTypeDto {
             name?: string;
             code?: string;
         }
@@ -2534,6 +2557,7 @@ declare namespace Paths {
             export type Page = number;
             export type PlayerIds = string[];
             export type PositionIds = string[];
+            export type PositionTypeIds = string[];
             export type SortBy = "id" | "player" | "createdAt";
             export type SortingOrder = "asc" | "desc";
             export type TeamIds = string[];
@@ -2541,6 +2565,7 @@ declare namespace Paths {
         export interface QueryParameters {
             playerIds?: Parameters.PlayerIds;
             positionIds?: Parameters.PositionIds;
+            positionTypeIds?: Parameters.PositionTypeIds;
             teamIds?: Parameters.TeamIds;
             competitionIds?: Parameters.CompetitionIds;
             competitionGroupIds?: Parameters.CompetitionGroupIds;
@@ -2976,6 +3001,7 @@ declare namespace Paths {
             export type PlayerBornBefore = number;
             export type PlayerIds = string[];
             export type PositionIds = string[];
+            export type PositionTypeIds = string[];
             export type SortBy = "id" | "player" | "positionPlayed" | "percentageRating" | "match" | "author" | "createdAt" | "percentageRating_createdAt";
             export type SortingOrder = "asc" | "desc";
             export type TeamIds = string[];
@@ -2984,6 +3010,7 @@ declare namespace Paths {
         export interface QueryParameters {
             playerIds?: Parameters.PlayerIds;
             positionIds?: Parameters.PositionIds;
+            positionTypeIds?: Parameters.PositionTypeIds;
             teamIds?: Parameters.TeamIds;
             matchIds?: Parameters.MatchIds;
             competitionIds?: Parameters.CompetitionIds;
@@ -3756,6 +3783,115 @@ declare namespace Paths {
             }
         }
     }
+    namespace PlayerPositionTypesControllerCreate {
+        export type RequestBody = Components.Schemas.CreatePlayerPositionTypeDto;
+        namespace Responses {
+            export interface $201 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerPositionTypeDto;
+            }
+        }
+    }
+    namespace PlayerPositionTypesControllerFindAll {
+        namespace Parameters {
+            export type Code = string;
+            export type Limit = number;
+            export type Name = string;
+            export type Page = number;
+            export type SortBy = "id" | "name" | "code";
+            export type SortingOrder = "asc" | "desc";
+        }
+        export interface QueryParameters {
+            name?: Parameters.Name;
+            code?: Parameters.Code;
+            sortBy?: Parameters.SortBy;
+            sortingOrder?: Parameters.SortingOrder;
+            limit?: Parameters.Limit;
+            page?: Parameters.Page;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: {
+                    totalDocs?: number;
+                    limit?: number;
+                    page?: number;
+                    totalPages?: number;
+                    hasPrevPage?: boolean;
+                    hasNextPage?: boolean;
+                    prevPage?: number | null;
+                    nextPage?: number | null;
+                    docs?: Components.Schemas.PlayerPositionTypeDto[];
+                };
+            }
+        }
+    }
+    namespace PlayerPositionTypesControllerFindOne {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerPositionTypeDto;
+            }
+        }
+    }
+    namespace PlayerPositionTypesControllerGetList {
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerPositionTypeDto[];
+            }
+        }
+    }
+    namespace PlayerPositionTypesControllerRemove {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerPositionTypeDto;
+            }
+        }
+    }
+    namespace PlayerPositionTypesControllerUpdate {
+        namespace Parameters {
+            export type Id = string;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.UpdatePlayerPositionTypeDto;
+        namespace Responses {
+            export interface $200 {
+                success: boolean;
+                message: string;
+                data?: Components.Schemas.PlayerPositionTypeDto;
+            }
+        }
+    }
+    namespace PlayerPositionTypesControllerUploadFile {
+        export interface RequestBody {
+            file?: string; // binary
+        }
+        namespace Responses {
+            export interface $201 {
+            }
+        }
+    }
     namespace PlayerPositionsControllerCreate {
         export type RequestBody = Components.Schemas.CreatePlayerPositionDto;
         namespace Responses {
@@ -3985,6 +4121,7 @@ declare namespace Paths {
             export type OrderId = string;
             export type Page = number;
             export type PositionIds = string[];
+            export type PositionTypeIds = string[];
             export type SortBy = "id" | "firstName" | "lastName" | "yearOfBirth" | "height" | "weight" | "footed" | "country" | "primaryPosition" | "reportsCount" | "notesCount" | "updatedAt";
             export type SortingOrder = "asc" | "desc";
             export type TeamIds = string[];
@@ -3996,6 +4133,7 @@ declare namespace Paths {
             footed?: Parameters.Footed;
             countryIds?: Parameters.CountryIds;
             positionIds?: Parameters.PositionIds;
+            positionTypeIds?: Parameters.PositionTypeIds;
             teamIds?: Parameters.TeamIds;
             competitionIds?: Parameters.CompetitionIds;
             competitionGroupIds?: Parameters.CompetitionGroupIds;
@@ -4072,6 +4210,7 @@ declare namespace Paths {
             export type Name = string;
             export type OrderId = string;
             export type PositionIds = string[];
+            export type PositionTypeIds = string[];
             export type TeamIds = string[];
         }
         export interface QueryParameters {
@@ -4081,6 +4220,7 @@ declare namespace Paths {
             footed?: Parameters.Footed;
             countryIds?: Parameters.CountryIds;
             positionIds?: Parameters.PositionIds;
+            positionTypeIds?: Parameters.PositionTypeIds;
             teamIds?: Parameters.TeamIds;
             competitionIds?: Parameters.CompetitionIds;
             competitionGroupIds?: Parameters.CompetitionGroupIds;
@@ -4732,6 +4872,7 @@ declare namespace Paths {
             export type PlayerBornBefore = number;
             export type PlayerIds = string[];
             export type PositionIds = string[];
+            export type PositionTypeIds = string[];
             export type SortBy = "id" | "player" | "positionPlayed" | "finalRating" | "percentageRating" | "videoUrl" | "author" | "createdAt" | "status" | "match";
             export type SortingOrder = "asc" | "desc";
             export type TeamIds = string[];
@@ -4740,6 +4881,7 @@ declare namespace Paths {
         export interface QueryParameters {
             playerIds?: Parameters.PlayerIds;
             positionIds?: Parameters.PositionIds;
+            positionTypeIds?: Parameters.PositionTypeIds;
             matchIds?: Parameters.MatchIds;
             teamIds?: Parameters.TeamIds;
             competitionIds?: Parameters.CompetitionIds;
@@ -4810,12 +4952,14 @@ declare namespace Paths {
             export type PlayerBornBefore = number;
             export type PlayerIds = string[];
             export type PositionIds = string[];
+            export type PositionTypeIds = string[];
             export type TeamIds = string[];
             export type UserId = string;
         }
         export interface QueryParameters {
             playerIds?: Parameters.PlayerIds;
             positionIds?: Parameters.PositionIds;
+            positionTypeIds?: Parameters.PositionTypeIds;
             matchIds?: Parameters.MatchIds;
             teamIds?: Parameters.TeamIds;
             competitionIds?: Parameters.CompetitionIds;

--- a/src/types/generated.d.ts
+++ b/src/types/generated.d.ts
@@ -218,6 +218,7 @@ declare namespace Components {
             competitionId: string;
             groupId?: string;
             seasonId: string;
+            transfermarktUrl?: string;
         }
         export interface CreateNoteDto {
             id?: string;
@@ -488,6 +489,7 @@ declare namespace Components {
             primaryPosition: PlayerPositionDto;
             secondaryPositions: PlayerPositionDto[];
             likes: LikePlayerBasicDataDto[];
+            averagePercentageRating: number;
             _count: Count;
         }
         export interface DashboardReportDto {
@@ -615,6 +617,7 @@ declare namespace Components {
             homeGoals?: number;
             awayGoals?: number;
             videoUrl?: string;
+            transfermarktUrl?: string;
             homeTeam: TeamBasicDataDto;
             awayTeam: TeamBasicDataDto;
             competition: CompetitionBasicDataDto;
@@ -789,6 +792,7 @@ declare namespace Components {
             secondaryPositions: PlayerPositionDto[];
             teams: TeamAffiliationWithoutPlayerDto[];
             likes: LikePlayerBasicDataDto[];
+            averagePercentageRating: number;
             _count: Count;
         }
         export interface PlayerPositionDto {
@@ -1090,6 +1094,7 @@ declare namespace Components {
             competitionId?: string;
             groupId?: string;
             seasonId?: string;
+            transfermarktUrl?: string;
         }
         export interface UpdateNoteDto {
             shirtNo?: number;
@@ -1128,6 +1133,7 @@ declare namespace Components {
             newPasswordConfirm: string;
         }
         export interface UpdatePlayerDto {
+            averagePercentageRating?: number;
             firstName?: string;
             lastName?: string;
             countryId?: string;
@@ -2992,6 +2998,7 @@ declare namespace Paths {
             export type ObservationType = "LIVE" | "VIDEO";
             export type OnlyLikedPlayers = boolean;
             export type OnlyLikedTeams = boolean;
+            export type OnlyMine = boolean;
             export type OnlyWithoutPlayers = boolean;
             export type Page = number;
             export type PercentageRatingRangeEnd = number;
@@ -3026,6 +3033,7 @@ declare namespace Paths {
             onlyLikedTeams?: Parameters.OnlyLikedTeams;
             onlyLikedPlayers?: Parameters.OnlyLikedPlayers;
             onlyWithoutPlayers?: Parameters.OnlyWithoutPlayers;
+            onlyMine?: Parameters.OnlyMine;
             sortBy?: Parameters.SortBy;
             sortingOrder?: Parameters.SortingOrder;
             limit?: Parameters.Limit;
@@ -4117,12 +4125,14 @@ declare namespace Paths {
             export type HasReport = boolean;
             export type IsLiked = boolean;
             export type Limit = number;
+            export type MaxAverageRating = number;
+            export type MinAverageRating = number;
             export type Name = string;
             export type OrderId = string;
             export type Page = number;
             export type PositionIds = string[];
             export type PositionTypeIds = string[];
-            export type SortBy = "id" | "firstName" | "lastName" | "yearOfBirth" | "height" | "weight" | "footed" | "country" | "primaryPosition" | "reportsCount" | "notesCount" | "updatedAt";
+            export type SortBy = "id" | "firstName" | "lastName" | "yearOfBirth" | "height" | "weight" | "footed" | "country" | "primaryPosition" | "reportsCount" | "notesCount" | "updatedAt" | "averagePercentageRating";
             export type SortingOrder = "asc" | "desc";
             export type TeamIds = string[];
         }
@@ -4142,6 +4152,8 @@ declare namespace Paths {
             hasNote?: Parameters.HasNote;
             hasReport?: Parameters.HasReport;
             hasAnyObservation?: Parameters.HasAnyObservation;
+            minAverageRating?: Parameters.MinAverageRating;
+            maxAverageRating?: Parameters.MaxAverageRating;
             sortBy?: Parameters.SortBy;
             sortingOrder?: Parameters.SortingOrder;
             limit?: Parameters.Limit;
@@ -4207,6 +4219,8 @@ declare namespace Paths {
             export type HasNote = boolean;
             export type HasReport = boolean;
             export type IsLiked = boolean;
+            export type MaxAverageRating = number;
+            export type MinAverageRating = number;
             export type Name = string;
             export type OrderId = string;
             export type PositionIds = string[];
@@ -4229,6 +4243,8 @@ declare namespace Paths {
             hasNote?: Parameters.HasNote;
             hasReport?: Parameters.HasReport;
             hasAnyObservation?: Parameters.HasAnyObservation;
+            minAverageRating?: Parameters.MinAverageRating;
+            maxAverageRating?: Parameters.MaxAverageRating;
         }
         namespace Responses {
             export interface $200 {
@@ -4864,6 +4880,7 @@ declare namespace Paths {
             export type ObservationType = "LIVE" | "VIDEO";
             export type OnlyLikedPlayers = boolean;
             export type OnlyLikedTeams = boolean;
+            export type OnlyMine = boolean;
             export type Page = number;
             export type PercentageRatingRangeEnd = number;
             export type PercentageRatingRangeStart = number;
@@ -4897,6 +4914,7 @@ declare namespace Paths {
             observationType?: Parameters.ObservationType;
             onlyLikedTeams?: Parameters.OnlyLikedTeams;
             onlyLikedPlayers?: Parameters.OnlyLikedPlayers;
+            onlyMine?: Parameters.OnlyMine;
             sortBy?: Parameters.SortBy;
             sortingOrder?: Parameters.SortingOrder;
             limit?: Parameters.Limit;
@@ -4945,6 +4963,7 @@ declare namespace Paths {
             export type ObservationType = "LIVE" | "VIDEO";
             export type OnlyLikedPlayers = boolean;
             export type OnlyLikedTeams = boolean;
+            export type OnlyMine = boolean;
             export type PercentageRatingRangeEnd = number;
             export type PercentageRatingRangeStart = number;
             export type PercentageRatingRanges = ("ALL" | "NEGATIVE_SELECTION" | "NO_DECISION" | "TO_OBSERVE" | "POSITIVE_SELECTION")[];
@@ -4975,6 +4994,7 @@ declare namespace Paths {
             observationType?: Parameters.ObservationType;
             onlyLikedTeams?: Parameters.OnlyLikedTeams;
             onlyLikedPlayers?: Parameters.OnlyLikedPlayers;
+            onlyMine?: Parameters.OnlyMine;
         }
         namespace Responses {
             export interface $200 {


### PR DESCRIPTION
⚠️ requires https://github.com/scoutmaker/scoutmaker-backend-v2-nest/pull/163 to be merged

[SCOUT-329](https://playmakerpro.atlassian.net/browse/SCOUT-329)

### Task Description

- Regenerate & create types for `player-position-types` module
- Create service methods & hooks for data fetching
- Replace filter combos in `insider-notes`, `notes`, `players` & `reports` modules (we want to filter by more general position instead of a detailed one)
- Display detailed position with general position indicator in relevant modules

### Additional Notes (optional)

<!-- Provide any additional notes: related PRs, screenshots, et al.). -->
