### PR TITLE
Feat/scout 390 nav logo

### DIFF
--- a/src/components/logo/Logo.tsx
+++ b/src/components/logo/Logo.tsx
@@ -1,4 +1,3 @@
-import { Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import Image from 'next/image'
 

--- a/src/components/logo/Logo.tsx
+++ b/src/components/logo/Logo.tsx
@@ -23,8 +23,5 @@ export const Logo = () => (
     <StyledImageContainer>
       <Image src={logoWhite} alt="PlaymakerPro Logo" objectFit="cover" />
     </StyledImageContainer>
-    <Typography variant="h5" noWrap component="h1">
-      ScoutMaker Pro
-    </Typography>
   </StyledContainer>
 )

--- a/src/components/topbar/Topbar.tsx
+++ b/src/components/topbar/Topbar.tsx
@@ -34,7 +34,7 @@ export const Topbar = ({ matchAttendance }: ITopbarProps) => {
   return (
     <AppBar position="fixed" sx={{ zIndex: 5000 }}>
       <StyledToolbar>
-        <Link href="/" passHref>
+        <Link href="/dashboard" passHref>
           <StyledTitle>
             <Logo />
           </StyledTitle>


### PR DESCRIPTION
[SCOUT-390](https://playmakerpro.atlassian.net/browse/SCOUT-390)

### Task Description
- remove `ScoutMaker Pro` text from header
- clicking logo now redirects to `/dashboard`

### Additional Notes (optional)

<!-- Provide any additional notes: related PRs, screenshots, et al.). -->
